### PR TITLE
Add developer productivity module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Termux CLI Toolkit is a collection of handy command line tools for Android devel
 - Safe git push and pull helpers
 - Quick alias setup for your own scripts
 - Simple manual pages accessible with `mini-man`
+- New developer utilities in `mini-man dev`
 
 ![screenshot](docs/screenshot.png)
 

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,0 +1,5 @@
+# Developer Tools Module
+
+This folder contains guides and tips for using the developer-focused scripts in the Termux CLI Toolkit.
+
+Stay tuned for blog posts and tutorials.

--- a/install-toolkit.sh
+++ b/install-toolkit.sh
@@ -11,7 +11,7 @@ mkdir -p "$BIN" "$MAN"
 cp scripts/*/*.sh "$BIN" 2>/dev/null || true
 cp scripts/system/mini-man "$BIN"
 
-cp man/* "$MAN" 2>/dev/null || true
+cp -r man/* "$MAN" 2>/dev/null || true
 
 chmod +x "$BIN"/*
 

--- a/man/dev/dev-notes.man
+++ b/man/dev/dev-notes.man
@@ -1,0 +1,6 @@
+dev-notes - open a project notes file
+
+Usage:
+  dev-notes [file]
+
+Opens the specified markdown file in \$EDITOR for quick notes.

--- a/man/dev/kill-switch.man
+++ b/man/dev/kill-switch.man
@@ -1,0 +1,6 @@
+kill-switch - terminate processes safely
+
+Usage:
+  kill-switch <keyword>
+
+Lists matching processes and prompts before killing them.

--- a/man/dev/newproject.man
+++ b/man/dev/newproject.man
@@ -1,0 +1,6 @@
+newproject - scaffold a new project directory
+
+Usage:
+  newproject [name] [--node] [--python]
+
+Creates a folder, initializes git and README. Optional Node or Python setup.

--- a/man/dev/setupdev.man
+++ b/man/dev/setupdev.man
@@ -1,0 +1,6 @@
+setupdev - install common development packages
+
+Usage:
+  setupdev
+
+Installs git, curl, nodejs, python, sqlite and more for Termux.

--- a/man/dev/startserver.man
+++ b/man/dev/startserver.man
@@ -1,0 +1,6 @@
+startserver - launch development server
+
+Usage:
+  startserver [path]
+
+Detects project type and runs the appropriate dev server.

--- a/man/dev/switchenv.man
+++ b/man/dev/switchenv.man
@@ -1,0 +1,6 @@
+switchenv - swap .env presets
+
+Usage:
+  switchenv <file|list>
+
+Copies the chosen preset to .env in the current directory.

--- a/man/dev/updatedeps.man
+++ b/man/dev/updatedeps.man
@@ -1,0 +1,6 @@
+updatedeps - update project dependencies
+
+Usage:
+  updatedeps
+
+Updates npm and Python packages if their config files exist.

--- a/man/dev/watch.man
+++ b/man/dev/watch.man
@@ -1,0 +1,6 @@
+watch - watch files for modifications
+
+Usage:
+  watch [path]
+
+Requires inotifywait. Prints a message whenever files change.

--- a/scripts/dev/dev-notes.sh
+++ b/scripts/dev/dev-notes.sh
@@ -1,0 +1,16 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  mini-man dev dev-notes
+  exit 0
+fi
+
+usage() {
+  echo "dev-notes - open scratch notes"
+  echo "Usage: dev-notes [file]"
+}
+
+FILE="${1:-DEV_NOTES.md}"
+
+${EDITOR:-nano} "$FILE"

--- a/scripts/dev/kill-switch.sh
+++ b/scripts/dev/kill-switch.sh
@@ -1,0 +1,33 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  mini-man dev kill-switch
+  exit 0
+fi
+
+usage() {
+  echo "kill-switch - stop processes by keyword"
+  echo "Usage: kill-switch <keyword>"
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+KEY=$1
+
+procs=$(pgrep -fl "$KEY" | grep -v "kill-switch" || true)
+if [[ -z $procs ]]; then
+  echo "❌ No matching processes" >&2
+  exit 1
+fi
+
+echo "Matching processes:" && echo "$procs"
+read -rp "Kill these processes? (y/N) " confirm
+if [[ $confirm != "y" && $confirm != "Y" ]]; then
+  echo "Aborted." && exit 0
+fi
+
+pkill -f "$KEY" && echo "✅ Processes terminated"

--- a/scripts/dev/newproject.sh
+++ b/scripts/dev/newproject.sh
@@ -1,0 +1,64 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  mini-man dev newproject
+  exit 0
+fi
+
+usage() {
+  echo "newproject - scaffold a new project"
+  echo "Usage: newproject [name] [--node] [--python]"
+}
+
+project="."
+node=false
+python=false
+
+for arg in "$@"; do
+  case $arg in
+    --node) node=true ;;
+    --python) python=true ;;
+    -h|--help) mini-man dev newproject; exit 0 ;;
+    *) project="$arg" ;;
+  esac
+  shift || true
+done
+
+if [[ $project != "." ]]; then
+  mkdir -p "$project"
+  cd "$project"
+fi
+
+echo "🌱 Creating project in $(pwd)"
+
+if [[ ! -f README.md ]]; then
+  echo "# $(basename $(pwd))" > README.md
+  echo "✅ README created"
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  git init >/dev/null
+  echo "✅ Git repository initialized"
+fi
+
+if $node; then
+  if command -v npm >/dev/null 2>&1; then
+    if [[ ! -f package.json ]]; then
+      npm init -y >/dev/null && echo "✅ npm project initialized"
+    fi
+  else
+    echo "❌ npm not installed" >&2
+  fi
+fi
+
+if $python; then
+  if command -v python >/dev/null 2>&1; then
+    [[ -f requirements.txt ]] || touch requirements.txt
+    echo "✅ Python requirements file ready"
+  else
+    echo "❌ Python not installed" >&2
+  fi
+fi
+
+echo "🎉 Project setup complete"

--- a/scripts/dev/setupdev.sh
+++ b/scripts/dev/setupdev.sh
@@ -1,0 +1,28 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  mini-man dev setupdev
+  exit 0
+fi
+
+usage() {
+  echo "setupdev - install common dev packages"
+  echo "Usage: setupdev"
+}
+
+read -rp "Install common dev packages (git, curl, nodejs, python, sqlite)? (y/N) " ans
+if [[ $ans != "y" && $ans != "Y" ]]; then
+  echo "Aborted." && exit 0
+fi
+
+# network check
+if ! ping -c1 -W1 8.8.8.8 >/dev/null 2>&1; then
+  echo "❌ Network unreachable. Try again later or install packages manually." >&2
+  exit 1
+fi
+
+pkg update -y
+pkg install -y git curl nodejs python sqlite nano inotify-tools
+
+echo "✅ Development packages installed"

--- a/scripts/dev/startserver.sh
+++ b/scripts/dev/startserver.sh
@@ -1,0 +1,38 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  mini-man dev startserver
+  exit 0
+fi
+
+usage() {
+  echo "startserver - launch dev server"
+  echo "Usage: startserver [path]"
+}
+
+DIR="${1:-.}"
+cd "$DIR"
+
+echo "🚀 Starting server in $(pwd)"
+
+if [[ -f package.json ]] && jq -e '.scripts.start' package.json >/dev/null 2>&1; then
+  echo "▶️ npm start"
+  npm start
+  exit 0
+fi
+
+if [[ -f manage.py ]]; then
+  echo "▶️ python manage.py runserver"
+  python manage.py runserver
+  exit 0
+fi
+
+if [[ -f app.py ]]; then
+  echo "▶️ python app.py"
+  python app.py
+  exit 0
+fi
+
+echo "❌ Could not detect server entry point" >&2
+exit 1

--- a/scripts/dev/switchenv.sh
+++ b/scripts/dev/switchenv.sh
@@ -1,0 +1,37 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  mini-man dev switchenv
+  exit 0
+fi
+
+usage() {
+  echo "switchenv - swap .env presets"
+  echo "Usage: switchenv <file|list>"
+}
+
+if [[ $# -eq 0 ]]; then
+  usage
+  exit 1
+fi
+
+if [[ $1 == "list" ]]; then
+  echo "Available env presets:"
+  ls .env.* 2>/dev/null || echo "(none)"
+  exit 0
+fi
+
+FILE=$1
+if [[ ! -f $FILE ]]; then
+  echo "❌ $FILE not found" >&2
+  exit 1
+fi
+
+read -rp "Replace .env with $FILE? (y/N) " confirm
+if [[ $confirm != "y" && $confirm != "Y" ]]; then
+  echo "Aborted." && exit 0
+fi
+
+cp "$FILE" .env
+echo "✅ .env updated from $FILE"

--- a/scripts/dev/updatedeps.sh
+++ b/scripts/dev/updatedeps.sh
@@ -1,0 +1,24 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  mini-man dev updatedeps
+  exit 0
+fi
+
+usage() {
+  echo "updatedeps - update project dependencies"
+  echo "Usage: updatedeps"
+}
+
+if [[ -f package.json ]]; then
+  echo "🔁 Updating npm packages..."
+  npm update && npm audit fix || true
+fi
+
+if [[ -f requirements.txt ]]; then
+  echo "🔁 Updating Python packages..."
+  pip install -U -r requirements.txt
+fi
+
+echo "✅ Dependencies updated"

--- a/scripts/dev/watch.sh
+++ b/scripts/dev/watch.sh
@@ -1,0 +1,27 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  mini-man dev watch
+  exit 0
+fi
+
+usage() {
+  echo "watch - watch files for changes"
+  echo "Usage: watch [path]"
+}
+
+PATH_TO_WATCH="${1:-.}"
+
+if ! command -v inotifywait >/dev/null 2>&1; then
+  echo "❌ inotifywait not installed" >&2
+  echo "Install with: pkg install inotify-tools" >&2
+  exit 1
+fi
+
+echo "🔁 Watching $PATH_TO_WATCH"
+
+inotifywait -m -r -e modify "$PATH_TO_WATCH" |
+while read -r path action file; do
+  echo "📄 $file changed"
+done

--- a/scripts/system/mini-man
+++ b/scripts/system/mini-man
@@ -4,7 +4,7 @@ set -euo pipefail
 # mini-man - simple manual viewer
 usage() {
   echo "mini-man - show toolkit manuals"
-  echo "Usage: mini-man [tool]"
+  echo "Usage: mini-man [category] [tool]"
 }
 
 MAN_DIR="$HOME/.termux-toolkit/man"
@@ -17,12 +17,28 @@ fi
 if [[ $# -eq 0 ]]; then
   echo "Available manuals:"
   find "$MAN_DIR" -maxdepth 1 -name "*.man" -printf '%f\n' | sed 's/\.man$//' | xargs -n1 -I{} echo " - {}"
+  for dir in "$MAN_DIR"/*/; do
+    [[ -d $dir ]] || continue
+    catname=$(basename "$dir")
+    echo " - $catname (category)"
+  done
   exit 0
 fi
 
-FILE="$MAN_DIR/$1.man"
+if [[ -d "$MAN_DIR/$1" ]]; then
+  CATEGORY=$1
+  if [[ $# -eq 1 ]]; then
+    echo "Available $CATEGORY manuals:"
+    find "$MAN_DIR/$CATEGORY" -name "*.man" -printf '%f\n' | sed 's/\.man$//' | xargs -n1 -I{} echo " - {}"
+    exit 0
+  fi
+  FILE="$MAN_DIR/$CATEGORY/$2.man"
+else
+  FILE="$MAN_DIR/$1.man"
+fi
+
 if [[ ! -f $FILE ]]; then
-  FILE="$MAN_DIR/$1.txt"
+  FILE="${FILE%.man}.txt"
 fi
 
 if [[ ! -f $FILE ]]; then


### PR DESCRIPTION
## Summary
- add `/scripts/dev` with several developer tools
- document dev scripts in `/man/dev`
- update `mini-man` to support categories
- copy manual directories during installation
- add placeholder docs and README notice

## Testing
- `bash -n scripts/dev/*.sh scripts/system/mini-man install-toolkit.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a2d59d00083339fccb3da7b31ebe7