### PR TITLE
Add toolkit core and config system

### DIFF
--- a/docs/TO_DO
+++ b/docs/TO_DO
@@ -1,0 +1,3 @@
+# Manual Steps
+- Review logs in `~/.termux-toolkit/logs/feedback.log` and summarize feedback on GitHub Discussions.
+- Share recovery instructions from `~/.termux-toolkit/logs/recovery.log` when issues occur.

--- a/install-toolkit.sh
+++ b/install-toolkit.sh
@@ -8,6 +8,17 @@ MAN="$TARGET/man"
 
 mkdir -p "$BIN" "$MAN"
 
+# install core library and default config
+cp toolkit-core.sh "$TARGET/"
+if [[ ! -f "$TARGET/config" ]]; then
+  cat <<'EOF' > "$TARGET/config"
+USE_EMOJIS=true
+AI_API_ENDPOINT="http://192.168.1.100:8000"
+DEFAULT_BACKUP_DIR="$HOME/backups"
+EOF
+fi
+mkdir -p "$TARGET/plugins"
+
 cp scripts/*/*.sh "$BIN" 2>/dev/null || true
 cp tools/*.sh "$BIN" 2>/dev/null || true
 cp scripts/system/mini-man "$BIN"
@@ -32,9 +43,20 @@ fi
 # aliases
 for script in "$BIN"/*; do
   name=$(basename "$script")
+  [[ $name == "toolkit-core.sh" ]] && continue
   name=${name%.sh}
   if ! grep -q "alias $name=" "$SHELL_RC" 2>/dev/null; then
     echo "alias $name=\"$script\"" >> "$SHELL_RC"
+  fi
+done
+
+# plugin aliases
+for plugin in "$TARGET/plugins"/*.sh; do
+  [[ -f $plugin ]] || continue
+  tool=$(grep -m1 '^# @tool' "$plugin" | awk '{print $3}')
+  [[ -n $tool ]] || continue
+  if ! grep -q "alias $tool=" "$SHELL_RC" 2>/dev/null; then
+    echo "alias $tool=\"$plugin\"" >> "$SHELL_RC"
   fi
 done
 

--- a/man/ttk-feedback.man
+++ b/man/ttk-feedback.man
@@ -1,0 +1,6 @@
+ttk-feedback - send feedback for Termux Toolkit
+
+Usage:
+  ttk-feedback [message]
+
+Saves the feedback to ~/.termux-toolkit/logs/feedback.log and attempts to POST it to the configured API endpoint.

--- a/scripts/dev/dev-notes.sh
+++ b/scripts/dev/dev-notes.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev dev-notes

--- a/scripts/dev/kill-switch.sh
+++ b/scripts/dev/kill-switch.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev kill-switch

--- a/scripts/dev/newproject.sh
+++ b/scripts/dev/newproject.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev newproject

--- a/scripts/dev/scaffold-maker.sh
+++ b/scripts/dev/scaffold-maker.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev scaffold-maker

--- a/scripts/dev/setupdev.sh
+++ b/scripts/dev/setupdev.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev setupdev

--- a/scripts/dev/startserver.sh
+++ b/scripts/dev/startserver.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev startserver

--- a/scripts/dev/switchenv.sh
+++ b/scripts/dev/switchenv.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev switchenv

--- a/scripts/dev/updatedeps.sh
+++ b/scripts/dev/updatedeps.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev updatedeps

--- a/scripts/dev/watch.sh
+++ b/scripts/dev/watch.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev watch

--- a/scripts/files/batch-rename.sh
+++ b/scripts/files/batch-rename.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files batch-rename

--- a/scripts/files/convert-docs.sh
+++ b/scripts/files/convert-docs.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files convert-docs

--- a/scripts/files/copy-files.sh
+++ b/scripts/files/copy-files.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files copy-files

--- a/scripts/files/find-dupes.sh
+++ b/scripts/files/find-dupes.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files find-dupes

--- a/scripts/files/move-files.sh
+++ b/scripts/files/move-files.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 LOG_DIR="$HOME/.termux-toolkit/logs"
 LOG_FILE="$LOG_DIR/move-files.log"
@@ -44,6 +45,8 @@ fi
 mkdir -p "$dest"
 
 > "$LOG_FILE"
+RECOVERY_FILE="$HOME/.termux-toolkit/logs/recovery.log"
+trap 'echo "Move interrupted. Run: move-files --undo" >> "$RECOVERY_FILE"' ERR
 
 echo "🔍 Preview:" 
 for f in "$src"/*; do

--- a/scripts/files/smart-clean.sh
+++ b/scripts/files/smart-clean.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files smart-clean

--- a/scripts/git/gpull.sh
+++ b/scripts/git/gpull.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 # gpull - Git pull with stash/apply safety
 usage() {
@@ -18,7 +19,7 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 # network check
-if ! ping -c1 -W1 8.8.8.8 >/dev/null 2>&1; then
+if ! check_network; then
   echo "❌ Network unreachable" >&2
   exit 1
 fi

--- a/scripts/git/gpush.sh
+++ b/scripts/git/gpush.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 # gpush - Safe git add/commit/push with confirmations
 usage() {
@@ -28,7 +29,7 @@ if [[ $confirm != "y" && $confirm != "Y" ]]; then
 fi
 
 # network check
-if ! ping -c1 -W1 8.8.8.8 >/dev/null 2>&1; then
+if ! check_network; then
   echo "❌ Network unreachable" >&2
   exit 1
 fi

--- a/scripts/git/wipe-history.sh
+++ b/scripts/git/wipe-history.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 # wipe-history - rewrite repository history to a single commit
 usage() {
@@ -16,6 +17,10 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "❌ Not inside a git repository" >&2
   exit 1
 fi
+
+RECOVERY_FILE="$HOME/.termux-toolkit/logs/recovery.log"
+orig_head=$(git rev-parse HEAD)
+trap 'echo "History wipe aborted. Restore with: git reset --hard $orig_head" >> "$RECOVERY_FILE"' ERR
 
 read -rp "This will rewrite history and force push. Continue? (y/N) " confirm
 if [[ $confirm != "y" && $confirm != "Y" ]]; then

--- a/scripts/security/antivirus-scan.sh
+++ b/scripts/security/antivirus-scan.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 source "${SCRIPT_DIR}/../security/security-common.sh"
 

--- a/scripts/security/backup-data.sh
+++ b/scripts/security/backup-data.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 source "${SCRIPT_DIR}/../security/security-common.sh"
 
@@ -18,11 +19,14 @@ require_tool gzip gzip
 check_storage_access
 
 read -rp "Source paths (space separated): " srcs
-read -rp "Destination directory: " dest
+read -rp "Destination directory [$DEFAULT_BACKUP_DIR]: " dest
+dest=${dest:-$DEFAULT_BACKUP_DIR}
 mkdir -p "$dest"
 
 ts=$(date +%Y%m%d_%H%M%S)
 archive="$dest/backup_$ts.tar.gz"
+RECOVERY_FILE="$HOME/.termux-toolkit/logs/recovery.log"
+trap 'echo "Backup interrupted. Partial file at $archive" >> "$RECOVERY_FILE"' ERR
 
 if $dry_run; then
   echo "Would archive $srcs to $archive"

--- a/scripts/security/ip-scan.sh
+++ b/scripts/security/ip-scan.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 source "${SCRIPT_DIR}/../security/security-common.sh"
 

--- a/scripts/security/network-check.sh
+++ b/scripts/security/network-check.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 source "${SCRIPT_DIR}/../security/security-common.sh"
 

--- a/scripts/security/scan-by-name.sh
+++ b/scripts/security/scan-by-name.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 source "${SCRIPT_DIR}/../security/security-common.sh"
 

--- a/scripts/security/security-common.sh
+++ b/scripts/security/security-common.sh
@@ -3,32 +3,10 @@ set -euo pipefail
 
 LOG_DIR="$HOME/.termux-toolkit/logs"
 mkdir -p "$LOG_DIR"
-
-# require_tool <cmd> [pkg]
-require_tool() {
-  local cmd="$1"
-  local pkg="${2:-$1}"
-  if ! command -v "$cmd" >/dev/null 2>&1; then
-    echo "ℹ️ Installing $pkg..." >&2
-    pkg install -y "$pkg"
-  fi
-}
-
-# ask_confirm "Prompt" -> returns 0 if yes
-ask_confirm() {
-  local prompt="$1"
-  read -rp "$prompt" ans
-  [[ $ans == "y" || $ans == "Y" ]]
-}
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 log_msg() {
   local msg="$1"
   echo "$(date '+%Y-%m-%d %H:%M:%S') $msg" >> "$LOG_DIR/security.log"
 }
 
-check_storage_access() {
-  if [[ ! -d $HOME/storage/shared ]]; then
-    echo "⚠️ Storage not set up. Running termux-setup-storage..." >&2
-    termux-setup-storage
-  fi
-}

--- a/scripts/security/zip-migrate.sh
+++ b/scripts/security/zip-migrate.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 source "${SCRIPT_DIR}/../security/security-common.sh"
 

--- a/scripts/system/fixer.sh
+++ b/scripts/system/fixer.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 # fixer - adds alias and makes script executable
 usage() {

--- a/scripts/system/mini-man
+++ b/scripts/system/mini-man
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 # mini-man - simple manual viewer
 usage() {

--- a/scripts/system/pkg-toolkit.sh
+++ b/scripts/system/pkg-toolkit.sh
@@ -1,5 +1,6 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
 
 usage() {
   echo "pkg-toolkit - install toolkit package batches"

--- a/scripts/system/ttk-feedback.sh
+++ b/scripts/system/ttk-feedback.sh
@@ -1,0 +1,25 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  echo "ttk-feedback - submit toolkit feedback"
+  echo "Usage: ttk-feedback [message]"
+  exit 0
+fi
+
+msg="$*"
+if [[ -z $msg ]]; then
+  read -rp "Feedback: " msg
+fi
+
+mkdir -p "$HOME/.termux-toolkit/logs"
+echo "$(date '+%F %T') $msg" >> "$HOME/.termux-toolkit/logs/feedback.log"
+log "user-feedback: $msg"
+
+# try sending to API endpoint if reachable
+if check_network; then
+  curl -fs -X POST "$AI_API_ENDPOINT" -d "feedback=$msg" >/dev/null 2>&1 || true
+fi
+
+echo "Thanks for your feedback!"

--- a/scripts/test/test-network.sh
+++ b/scripts/test/test-network.sh
@@ -1,0 +1,9 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
+
+if check_network; then
+  echo "✅ Network reachable"
+else
+  echo "❌ Network unreachable"
+fi

--- a/scripts/test/test-script.sh
+++ b/scripts/test/test-script.sh
@@ -1,0 +1,15 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
+
+script="$1"
+if [[ -z $script ]]; then
+  echo "Usage: test-script.sh <script>" >&2
+  exit 1
+fi
+
+if "$script" --help >/dev/null 2>&1; then
+  echo "✅ $script executed"
+else
+  echo "⚠️ $script returned error"
+fi

--- a/scripts/test/test-storage-access.sh
+++ b/scripts/test/test-storage-access.sh
@@ -1,0 +1,6 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+source "$HOME/.termux-toolkit/toolkit-core.sh"
+
+check_storage_access
+echo "✅ Storage access OK"

--- a/toolkit-core.sh
+++ b/toolkit-core.sh
@@ -1,0 +1,66 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+# toolkit-core - shared functions for Termux CLI Toolkit
+
+# Load configuration with defaults
+load_config() {
+  USE_EMOJIS=true
+  AI_API_ENDPOINT="http://192.168.1.100:8000"
+  DEFAULT_BACKUP_DIR="$HOME/backups"
+  if [[ -f $HOME/.termux-toolkit/config ]]; then
+    source "$HOME/.termux-toolkit/config"
+  fi
+}
+
+# ask_confirm "prompt" -> returns 0 if yes
+ask_confirm() {
+  local prompt="$1"
+  read -rp "$prompt" ans
+  [[ $ans == [yY] ]]
+}
+
+# require_tool <cmd> [pkg]
+require_tool() {
+  local cmd="$1"; local pkg="${2:-$1}"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "Installing $pkg..." >&2
+    pkg install -y "$pkg"
+  fi
+}
+
+# log <message>
+log() {
+  mkdir -p "$HOME/.termux-toolkit/logs"
+  echo "$(date '+%F %T') $1" >> "$HOME/.termux-toolkit/logs/toolkit.log"
+}
+
+# check_network -> returns 0 if reachable
+check_network() {
+  ping -c1 -W1 1.1.1.1 >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# print_banner
+print_banner() {
+  echo "=== Termux CLI Toolkit ==="
+}
+
+# ensure storage access
+check_storage_access() {
+  if [[ ! -d $HOME/storage/shared ]]; then
+    if command -v termux-setup-storage >/dev/null 2>&1; then
+      termux-setup-storage
+    fi
+  fi
+}
+
+# source all plugin files
+load_plugins() {
+  local dir="$HOME/.termux-toolkit/plugins"
+  for f in "$dir"/*.sh; do
+    [[ -f $f ]] && source "$f"
+  done
+}
+
+load_config


### PR DESCRIPTION
## Summary
- introduce shared `toolkit-core.sh` and load it from each script
- install default config during setup
- create feedback command and documentation
- add simple test scripts for network and storage
- implement basic recovery notes for some tools
- support plugin aliases on installation

## Testing
- `bash scripts/test/test-network.sh`
- `bash scripts/test/test-storage-access.sh`
- `bash scripts/test/test-script.sh scripts/git/gpush.sh`


------
https://chatgpt.com/codex/tasks/task_e_685a95758e7c8333adac477043e4bea3