### PR TITLE
Fix symlink path lookup

### DIFF
--- a/scripts/dev/dev-notes.sh
+++ b/scripts/dev/dev-notes.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev dev-notes

--- a/scripts/dev/kill-switch.sh
+++ b/scripts/dev/kill-switch.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev kill-switch

--- a/scripts/dev/newproject.sh
+++ b/scripts/dev/newproject.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev newproject

--- a/scripts/dev/scaffold-maker.sh
+++ b/scripts/dev/scaffold-maker.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev scaffold-maker

--- a/scripts/dev/setupdev.sh
+++ b/scripts/dev/setupdev.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev setupdev

--- a/scripts/dev/startserver.sh
+++ b/scripts/dev/startserver.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev startserver

--- a/scripts/dev/switchenv.sh
+++ b/scripts/dev/switchenv.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev switchenv

--- a/scripts/dev/updatedeps.sh
+++ b/scripts/dev/updatedeps.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev updatedeps

--- a/scripts/dev/watch.sh
+++ b/scripts/dev/watch.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev watch

--- a/scripts/files/batch-rename.sh
+++ b/scripts/files/batch-rename.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files batch-rename

--- a/scripts/files/convert-docs.sh
+++ b/scripts/files/convert-docs.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files convert-docs

--- a/scripts/files/copy-files.sh
+++ b/scripts/files/copy-files.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files copy-files

--- a/scripts/files/find-dupes.sh
+++ b/scripts/files/find-dupes.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files find-dupes

--- a/scripts/files/move-files.sh
+++ b/scripts/files/move-files.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 LOG_DIR="$HOME/.termux-toolkit/logs"
 LOG_FILE="$LOG_DIR/move-files.log"

--- a/scripts/files/smart-clean.sh
+++ b/scripts/files/smart-clean.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files smart-clean

--- a/scripts/git/gpull.sh
+++ b/scripts/git/gpull.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 # gpull - Git pull with stash/apply safety
 usage() {

--- a/scripts/git/gpush.sh
+++ b/scripts/git/gpush.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 # gpush - Safe git add/commit/push with confirmations
 usage() {

--- a/scripts/git/wipe-history.sh
+++ b/scripts/git/wipe-history.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 # wipe-history - rewrite repository history to a single commit
 usage() {

--- a/scripts/security/antivirus-scan.sh
+++ b/scripts/security/antivirus-scan.sh
@@ -1,8 +1,14 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
-source "${SCRIPT_DIR}/../security/security-common.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   echo "antivirus-scan - run clamscan on files or directories"

--- a/scripts/security/backup-data.sh
+++ b/scripts/security/backup-data.sh
@@ -1,8 +1,14 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
-source "${SCRIPT_DIR}/../security/security-common.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   echo "backup-data - interactive backup"

--- a/scripts/security/ip-scan.sh
+++ b/scripts/security/ip-scan.sh
@@ -1,8 +1,14 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
-source "${SCRIPT_DIR}/../security/security-common.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   echo "ip-scan - scan LAN with nmap"

--- a/scripts/security/network-check.sh
+++ b/scripts/security/network-check.sh
@@ -2,10 +2,16 @@
 #!/data/data/com.termux/files/usr/bin/bash
 
 set -euo pipefail
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
 
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
-source "${SCRIPT_DIR}/../security/security-common.sh"
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
+
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   echo "network-check - check connectivity"

--- a/scripts/security/scan-by-name.sh
+++ b/scripts/security/scan-by-name.sh
@@ -1,8 +1,14 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
-source "${SCRIPT_DIR}/../security/security-common.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 usage() {
   echo "scan-by-name - search by name and scan"

--- a/scripts/security/security-common.sh
+++ b/scripts/security/security-common.sh
@@ -1,8 +1,14 @@
 #!/data/data/com.termux/files/usr/bin/bash
 
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 LOG_DIR="$HOME/.termux-toolkit/logs"
 mkdir -p "$LOG_DIR"

--- a/scripts/security/zip-migrate.sh
+++ b/scripts/security/zip-migrate.sh
@@ -1,8 +1,14 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
-source "${SCRIPT_DIR}/../security/security-common.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   echo "zip-migrate - zip folder for migration"

--- a/scripts/system/about-toolkit.sh
+++ b/scripts/system/about-toolkit.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 version=$(cat "$HOME/.termux-toolkit/VERSION" 2>/dev/null || echo "unknown")
 log_info "Termux Toolkit $version"

--- a/scripts/system/fixer.sh
+++ b/scripts/system/fixer.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 # fixer - adds alias and makes script executable
 usage() {

--- a/scripts/system/memage.sh
+++ b/scripts/system/memage.sh
@@ -4,8 +4,14 @@
 # @desc Search $HOME + shared storage for a name and report size
 # @category system
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 # ----- prerequisites -----
 require_tool du   || exit 1

--- a/scripts/system/mini-man
+++ b/scripts/system/mini-man
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 # mini-man - simple manual viewer
 usage() {

--- a/scripts/system/pkg-toolkit.sh
+++ b/scripts/system/pkg-toolkit.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 require_tool pkg pkg || { log_error "pkg tool required"; exit 1; }
 

--- a/scripts/system/ttk-diagnose.sh
+++ b/scripts/system/ttk-diagnose.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 log_info "Running toolkit diagnostics..."
 

--- a/scripts/system/ttk-feedback.sh
+++ b/scripts/system/ttk-feedback.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   echo "ttk-feedback - submit toolkit feedback"

--- a/scripts/system/ttk-update.sh
+++ b/scripts/system/ttk-update.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 repo="$HOME/.termux-toolkit"
 

--- a/scripts/system/ttk.sh
+++ b/scripts/system/ttk.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 cmd=${1:-help}
 shift || true
 case $cmd in

--- a/scripts/test/test-network.sh
+++ b/scripts/test/test-network.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 if check_network; then
   echo "✅ Network reachable"

--- a/scripts/test/test-script.sh
+++ b/scripts/test/test-script.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 script="$1"
 if [[ -z $script ]]; then

--- a/scripts/test/test-storage-access.sh
+++ b/scripts/test/test-storage-access.sh
@@ -1,7 +1,13 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-SCRIPT_DIR="$(realpath "$(dirname "$0")")"
-source "${SCRIPT_DIR}/../system/toolkit-core.sh"
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
+TOOLKIT_ROOT="$(resolve_toolkit_path)"
+source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
 
 check_storage_access
 echo "✅ Storage access OK"

--- a/toolkit-core.sh
+++ b/toolkit-core.sh
@@ -1,6 +1,12 @@
 #!/data/data/com.termux/files/usr/bin/bash
 # toolkit-core.sh – shared helpers for every Termux-Toolkit script
 set -euo pipefail
+resolve_toolkit_path() {
+  local script_path
+  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
+  echo "$(dirname "$script_path")/../.."
+}
+
 
 CFG_FILE="$HOME/.termux-toolkit/config"
 [[ -f "$CFG_FILE" ]] && source "$CFG_FILE"


### PR DESCRIPTION
## Summary
- add `resolve_toolkit_path` helper in `toolkit-core.sh`
- use the helper to locate the toolkit root in all scripts

## Testing
- `bash scripts/test/test-network.sh`
- `bash scripts/test/test-storage-access.sh` *(fails: command not found)*
- `bash scripts/test/test-script.sh scripts/security/network-check.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b667d0f0c8333a11308d809473d75