### PR TITLE
Fix symlink resolution for toolkit scripts

### DIFF
--- a/install-toolkit.sh
+++ b/install-toolkit.sh
@@ -73,3 +73,7 @@ for plugin in "$TARGET/plugins"/*.sh; do
 done
 
 echo "✅ Installation complete. Restart your shell or run 'source $SHELL_RC'"
+
+# Set TOOLKIT_ROOT for easy overrides
+grep -qxF 'export TOOLKIT_ROOT="$HOME/Termux-toolkit"' "$SHELL_RC" || \
+  echo 'export TOOLKIT_ROOT="$HOME/Termux-toolkit"' >> "$SHELL_RC"

--- a/scripts/dev/dev-notes.sh
+++ b/scripts/dev/dev-notes.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev dev-notes

--- a/scripts/dev/kill-switch.sh
+++ b/scripts/dev/kill-switch.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev kill-switch

--- a/scripts/dev/newproject.sh
+++ b/scripts/dev/newproject.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev newproject

--- a/scripts/dev/scaffold-maker.sh
+++ b/scripts/dev/scaffold-maker.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev scaffold-maker

--- a/scripts/dev/setupdev.sh
+++ b/scripts/dev/setupdev.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev setupdev

--- a/scripts/dev/startserver.sh
+++ b/scripts/dev/startserver.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev startserver

--- a/scripts/dev/switchenv.sh
+++ b/scripts/dev/switchenv.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev switchenv

--- a/scripts/dev/updatedeps.sh
+++ b/scripts/dev/updatedeps.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev updatedeps

--- a/scripts/dev/watch.sh
+++ b/scripts/dev/watch.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man dev watch

--- a/scripts/files/batch-rename.sh
+++ b/scripts/files/batch-rename.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files batch-rename

--- a/scripts/files/convert-docs.sh
+++ b/scripts/files/convert-docs.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files convert-docs

--- a/scripts/files/copy-files.sh
+++ b/scripts/files/copy-files.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files copy-files

--- a/scripts/files/find-dupes.sh
+++ b/scripts/files/find-dupes.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files find-dupes

--- a/scripts/files/move-files.sh
+++ b/scripts/files/move-files.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 LOG_DIR="$HOME/.termux-toolkit/logs"
 LOG_FILE="$LOG_DIR/move-files.log"

--- a/scripts/files/smart-clean.sh
+++ b/scripts/files/smart-clean.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   mini-man files smart-clean

--- a/scripts/git/gpull.sh
+++ b/scripts/git/gpull.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 # gpull - Git pull with stash/apply safety
 usage() {

--- a/scripts/git/gpush.sh
+++ b/scripts/git/gpush.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 # gpush - Safe git add/commit/push with confirmations
 usage() {

--- a/scripts/git/wipe-history.sh
+++ b/scripts/git/wipe-history.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 # wipe-history - rewrite repository history to a single commit
 usage() {

--- a/scripts/security/antivirus-scan.sh
+++ b/scripts/security/antivirus-scan.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then

--- a/scripts/security/backup-data.sh
+++ b/scripts/security/backup-data.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then

--- a/scripts/security/ip-scan.sh
+++ b/scripts/security/ip-scan.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then

--- a/scripts/security/network-check.sh
+++ b/scripts/security/network-check.sh
@@ -1,15 +1,8 @@
-
 #!/data/data/com.termux/files/usr/bin/bash
 
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 

--- a/scripts/security/scan-by-name.sh
+++ b/scripts/security/scan-by-name.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 usage() {

--- a/scripts/security/security-common.sh
+++ b/scripts/security/security-common.sh
@@ -1,14 +1,8 @@
 #!/data/data/com.termux/files/usr/bin/bash
 
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 LOG_DIR="$HOME/.termux-toolkit/logs"
 mkdir -p "$LOG_DIR"

--- a/scripts/security/zip-migrate.sh
+++ b/scripts/security/zip-migrate.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then

--- a/scripts/system/about-toolkit.sh
+++ b/scripts/system/about-toolkit.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 version=$(cat "$HOME/.termux-toolkit/VERSION" 2>/dev/null || echo "unknown")
 log_info "Termux Toolkit $version"

--- a/scripts/system/fixer.sh
+++ b/scripts/system/fixer.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 # fixer - adds alias and makes script executable
 usage() {

--- a/scripts/system/memage.sh
+++ b/scripts/system/memage.sh
@@ -4,14 +4,8 @@
 # @desc Search $HOME + shared storage for a name and report size
 # @category system
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 # ----- prerequisites -----
 require_tool du   || exit 1

--- a/scripts/system/mini-man
+++ b/scripts/system/mini-man
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 # mini-man - simple manual viewer
 usage() {

--- a/scripts/system/pkg-toolkit.sh
+++ b/scripts/system/pkg-toolkit.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 require_tool pkg pkg || { log_error "pkg tool required"; exit 1; }
 

--- a/scripts/system/toolkit-core.sh
+++ b/scripts/system/toolkit-core.sh
@@ -2,6 +2,19 @@
 # toolkit-core.sh – shared helpers for every Termux-Toolkit script
 set -euo pipefail
 
+# Resolve the real toolkit root even when sourced via symlink
+resolve_toolkit_root() {
+  local src file
+  src="${BASH_SOURCE[0]}"
+  while [ -h "$src" ]; do
+    file="$(readlink "$src")"
+    [[ $file != /* ]] && src="$(dirname "$src")/$file" || src="$file"
+  done
+  src="$(realpath "$src")"
+  echo "$(dirname "$src")/../.." | xargs realpath
+}
+export TOOLKIT_ROOT="$(resolve_toolkit_root)"
+
 # ---------- CONFIG ----------
 CFG_FILE="$HOME/.termux-toolkit/config"
 [[ -f "$CFG_FILE" ]] && source "$CFG_FILE"

--- a/scripts/system/ttk-diagnose.sh
+++ b/scripts/system/ttk-diagnose.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 log_info "Running toolkit diagnostics..."
 

--- a/scripts/system/ttk-feedback.sh
+++ b/scripts/system/ttk-feedback.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
   echo "ttk-feedback - submit toolkit feedback"

--- a/scripts/system/ttk-update.sh
+++ b/scripts/system/ttk-update.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 repo="$HOME/.termux-toolkit"
 

--- a/scripts/system/ttk.sh
+++ b/scripts/system/ttk.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 cmd=${1:-help}
 shift || true
 case $cmd in

--- a/scripts/test/test-network.sh
+++ b/scripts/test/test-network.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 if check_network; then
   echo "✅ Network reachable"

--- a/scripts/test/test-script.sh
+++ b/scripts/test/test-script.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 script="$1"
 if [[ -z $script ]]; then

--- a/scripts/test/test-storage-access.sh
+++ b/scripts/test/test-storage-access.sh
@@ -1,13 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 set -euo pipefail
-resolve_toolkit_path() {
-  local script_path
-  script_path="$(readlink -f "$0" 2>/dev/null || realpath "$0")"
-  echo "$(dirname "$script_path")/../.."
-}
 
-TOOLKIT_ROOT="$(resolve_toolkit_path)"
-source "$TOOLKIT_ROOT/scripts/system/toolkit-core.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
 check_storage_access
 echo "✅ Storage access OK"


### PR DESCRIPTION
## Summary
- ensure toolkit-core.sh resolves the real repository root
- source toolkit-core.sh using BASH_SOURCE and rely on `$TOOLKIT_ROOT`
- update install-toolkit.sh to export TOOLKIT_ROOT in shell rc

## Testing
- `bash scripts/security/ip-scan.sh --help`
- `bash scripts/security/network-check.sh --help`
- `bash scripts/test/test-script.sh scripts/security/ip-scan.sh` *(fails: required file not found)*
- `bash scripts/test/test-network.sh`
- `bash scripts/test/test-storage-access.sh`

------
https://chatgpt.com/codex/tasks/task_e_685b6b5a4ff483339c1e5a90bc2b0453