### PR TITLE
Fix security script helpers

### DIFF
--- a/scripts/security/antivirus-scan.sh
+++ b/scripts/security/antivirus-scan.sh
@@ -13,7 +13,7 @@ fi
 require_tool clamscan clamav
 require_tool freshclam clamav
 
-check_storage_access
+check_storage
 
 LOG="$HOME/.termux-toolkit/logs/security-antivirus.log"
 

--- a/scripts/security/backup-data.sh
+++ b/scripts/security/backup-data.sh
@@ -16,7 +16,7 @@ dry_run=false
 require_tool tar tar
 require_tool gzip gzip
 
-check_storage_access
+check_storage
 
 read -rp "Source paths (space separated): " srcs
 read -rp "Destination directory [$DEFAULT_BACKUP_DIR]: " dest

--- a/scripts/security/scan-by-name.sh
+++ b/scripts/security/scan-by-name.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 source "$TOOLKIT_ROOT/scripts/security/security-common.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
   echo "scan-by-name - search by name and scan"
@@ -28,7 +29,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-check_storage_access
+check_storage
 
 search_paths=("$HOME" "$HOME/storage/shared" "${extra_paths[@]}")
 mapfile -t results < <(find "${search_paths[@]}" -name "$name" 2>/dev/null)

--- a/scripts/security/security-common.sh
+++ b/scripts/security/security-common.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
+: "${DEFAULT_BACKUP_DIR:=$HOME/backups}"
+
 LOG_DIR="$HOME/.termux-toolkit/logs"
 mkdir -p "$LOG_DIR"
 

--- a/scripts/security/zip-migrate.sh
+++ b/scripts/security/zip-migrate.sh
@@ -15,7 +15,7 @@ folder="${1:-}"
 
 require_tool zip zip
 
-check_storage_access
+check_storage
 
 dest="$HOME/backups"
 mkdir -p "$dest"

--- a/scripts/test/test-storage-access.sh
+++ b/scripts/test/test-storage-access.sh
@@ -3,5 +3,5 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
 
-check_storage_access
+check_storage
 echo "✅ Storage access OK"


### PR DESCRIPTION
## Summary
- fix check_storage() usage in security scripts
- set DEFAULT_BACKUP_DIR fallback
- add SCRIPT_DIR variable in scan-by-name
- update storage access test

## Testing
- `bash scripts/test/test-storage-access.sh`
- `bash scripts/test/test-network.sh`


------
https://chatgpt.com/codex/tasks/task_e_685b7030fb9c8333926fbd50162eeffc