### PR TITLE
Add scaffold structure with placeholder scripts

### DIFF
--- a/.termux-toolkit/assets/logo.txt
+++ b/.termux-toolkit/assets/logo.txt
@@ -1,0 +1,1 @@
+Termux Toolkit

--- a/.termux-toolkit/bin/fixer.sh
+++ b/.termux-toolkit/bin/fixer.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for fixer.sh

--- a/.termux-toolkit/bin/mini-man.sh
+++ b/.termux-toolkit/bin/mini-man.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for mini-man.sh

--- a/.termux-toolkit/bin/newproject.sh
+++ b/.termux-toolkit/bin/newproject.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for newproject.sh

--- a/.termux-toolkit/bin/pkg-toolkit.sh
+++ b/.termux-toolkit/bin/pkg-toolkit.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for pkg-toolkit.sh

--- a/.termux-toolkit/bin/toolkit-core.sh
+++ b/.termux-toolkit/bin/toolkit-core.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for toolkit-core.sh

--- a/.termux-toolkit/bin/ttk
+++ b/.termux-toolkit/bin/ttk
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for ttk

--- a/.termux-toolkit/bin/ttk-feedback.sh
+++ b/.termux-toolkit/bin/ttk-feedback.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for ttk-feedback.sh

--- a/.termux-toolkit/man/README.md
+++ b/.termux-toolkit/man/README.md
@@ -1,0 +1,1 @@
+Toolkit manual pages

--- a/.termux-toolkit/scripts/ai/ai-helper-mode.sh
+++ b/.termux-toolkit/scripts/ai/ai-helper-mode.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for ai-helper-mode.sh

--- a/.termux-toolkit/scripts/ai/chatbot-lite.sh
+++ b/.termux-toolkit/scripts/ai/chatbot-lite.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for chatbot-lite.sh

--- a/.termux-toolkit/scripts/ai/code-review-bot.sh
+++ b/.termux-toolkit/scripts/ai/code-review-bot.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for code-review-bot.sh

--- a/.termux-toolkit/scripts/ai/embed-extract.sh
+++ b/.termux-toolkit/scripts/ai/embed-extract.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for embed-extract.sh

--- a/.termux-toolkit/scripts/ai/generate-text.sh
+++ b/.termux-toolkit/scripts/ai/generate-text.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for generate-text.sh

--- a/.termux-toolkit/scripts/ai/image-to-ascii.sh
+++ b/.termux-toolkit/scripts/ai/image-to-ascii.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for image-to-ascii.sh

--- a/.termux-toolkit/scripts/ai/local-nlp.sh
+++ b/.termux-toolkit/scripts/ai/local-nlp.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for local-nlp.sh

--- a/.termux-toolkit/scripts/ai/offline-tts.sh
+++ b/.termux-toolkit/scripts/ai/offline-tts.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for offline-tts.sh

--- a/.termux-toolkit/scripts/ai/shell-summarizer.sh
+++ b/.termux-toolkit/scripts/ai/shell-summarizer.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for shell-summarizer.sh

--- a/.termux-toolkit/scripts/ai/smart-undo.sh
+++ b/.termux-toolkit/scripts/ai/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/ai/vision-lite.sh
+++ b/.termux-toolkit/scripts/ai/vision-lite.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for vision-lite.sh

--- a/.termux-toolkit/scripts/automation/auto-backup.sh
+++ b/.termux-toolkit/scripts/automation/auto-backup.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for auto-backup.sh

--- a/.termux-toolkit/scripts/automation/auto-cleanup.sh
+++ b/.termux-toolkit/scripts/automation/auto-cleanup.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for auto-cleanup.sh

--- a/.termux-toolkit/scripts/automation/auto-update-toolkit.sh
+++ b/.termux-toolkit/scripts/automation/auto-update-toolkit.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for auto-update-toolkit.sh

--- a/.termux-toolkit/scripts/automation/batch-rename.sh
+++ b/.termux-toolkit/scripts/automation/batch-rename.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for batch-rename.sh

--- a/.termux-toolkit/scripts/automation/cron-builder.sh
+++ b/.termux-toolkit/scripts/automation/cron-builder.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for cron-builder.sh

--- a/.termux-toolkit/scripts/automation/email-pinger.sh
+++ b/.termux-toolkit/scripts/automation/email-pinger.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for email-pinger.sh

--- a/.termux-toolkit/scripts/automation/git-auto-push.sh
+++ b/.termux-toolkit/scripts/automation/git-auto-push.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for git-auto-push.sh

--- a/.termux-toolkit/scripts/automation/notify-me.sh
+++ b/.termux-toolkit/scripts/automation/notify-me.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for notify-me.sh

--- a/.termux-toolkit/scripts/automation/smart-undo.sh
+++ b/.termux-toolkit/scripts/automation/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/automation/sync-folders.sh
+++ b/.termux-toolkit/scripts/automation/sync-folders.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for sync-folders.sh

--- a/.termux-toolkit/scripts/automation/task-scheduler.sh
+++ b/.termux-toolkit/scripts/automation/task-scheduler.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for task-scheduler.sh

--- a/.termux-toolkit/scripts/bugsy-lite/README.md
+++ b/.termux-toolkit/scripts/bugsy-lite/README.md
@@ -1,0 +1,1 @@
+Bugsy Lite translation helpers.

--- a/.termux-toolkit/scripts/bugsy-lite/bash-translator.sh
+++ b/.termux-toolkit/scripts/bugsy-lite/bash-translator.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for bash-translator.sh

--- a/.termux-toolkit/scripts/bugsy-lite/css-translator.sh
+++ b/.termux-toolkit/scripts/bugsy-lite/css-translator.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for css-translator.sh

--- a/.termux-toolkit/scripts/bugsy-lite/html-translator.sh
+++ b/.termux-toolkit/scripts/bugsy-lite/html-translator.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for html-translator.sh

--- a/.termux-toolkit/scripts/bugsy-lite/js-translator.sh
+++ b/.termux-toolkit/scripts/bugsy-lite/js-translator.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for js-translator.sh

--- a/.termux-toolkit/scripts/bugsy-lite/python-translator.sh
+++ b/.termux-toolkit/scripts/bugsy-lite/python-translator.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for python-translator.sh

--- a/.termux-toolkit/scripts/dev/create-react-app-with-tunnel.sh
+++ b/.termux-toolkit/scripts/dev/create-react-app-with-tunnel.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for create-react-app-with-tunnel.sh

--- a/.termux-toolkit/scripts/dev/github-followers.sh
+++ b/.termux-toolkit/scripts/dev/github-followers.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for github-followers.sh

--- a/.termux-toolkit/scripts/dev/newproject.sh
+++ b/.termux-toolkit/scripts/dev/newproject.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for newproject.sh

--- a/.termux-toolkit/scripts/dev/postgresql_setup.sh
+++ b/.termux-toolkit/scripts/dev/postgresql_setup.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for postgresql_setup.sh

--- a/.termux-toolkit/scripts/dev/serve-static.sh
+++ b/.termux-toolkit/scripts/dev/serve-static.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for serve-static.sh

--- a/.termux-toolkit/scripts/dev/setupdev.sh
+++ b/.termux-toolkit/scripts/dev/setupdev.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for setupdev.sh

--- a/.termux-toolkit/scripts/dev/smart-undo.sh
+++ b/.termux-toolkit/scripts/dev/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/dev/switchenv.sh
+++ b/.termux-toolkit/scripts/dev/switchenv.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for switchenv.sh

--- a/.termux-toolkit/scripts/dev/updatedeps.sh
+++ b/.termux-toolkit/scripts/dev/updatedeps.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for updatedeps.sh

--- a/.termux-toolkit/scripts/dev/watch.sh
+++ b/.termux-toolkit/scripts/dev/watch.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for watch.sh

--- a/.termux-toolkit/scripts/files/analyze-storage.sh
+++ b/.termux-toolkit/scripts/files/analyze-storage.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for analyze-storage.sh

--- a/.termux-toolkit/scripts/files/archive-folder.sh
+++ b/.termux-toolkit/scripts/files/archive-folder.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for archive-folder.sh

--- a/.termux-toolkit/scripts/files/backup.sh
+++ b/.termux-toolkit/scripts/files/backup.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for backup.sh

--- a/.termux-toolkit/scripts/files/batch-mv.sh
+++ b/.termux-toolkit/scripts/files/batch-mv.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for batch-mv.sh

--- a/.termux-toolkit/scripts/files/cleanup-temp.sh
+++ b/.termux-toolkit/scripts/files/cleanup-temp.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for cleanup-temp.sh

--- a/.termux-toolkit/scripts/files/extract-text.sh
+++ b/.termux-toolkit/scripts/files/extract-text.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for extract-text.sh

--- a/.termux-toolkit/scripts/files/find-large.sh
+++ b/.termux-toolkit/scripts/files/find-large.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for find-large.sh

--- a/.termux-toolkit/scripts/files/image-convert.sh
+++ b/.termux-toolkit/scripts/files/image-convert.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for image-convert.sh

--- a/.termux-toolkit/scripts/files/mount-storage.sh
+++ b/.termux-toolkit/scripts/files/mount-storage.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for mount-storage.sh

--- a/.termux-toolkit/scripts/files/smart-scaffold.sh
+++ b/.termux-toolkit/scripts/files/smart-scaffold.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-scaffold.sh

--- a/.termux-toolkit/scripts/files/smart-undo.sh
+++ b/.termux-toolkit/scripts/files/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/monitoring/battery-health.sh
+++ b/.termux-toolkit/scripts/monitoring/battery-health.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for battery-health.sh

--- a/.termux-toolkit/scripts/monitoring/cpu-loadgraph.sh
+++ b/.termux-toolkit/scripts/monitoring/cpu-loadgraph.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for cpu-loadgraph.sh

--- a/.termux-toolkit/scripts/monitoring/diskwatch.sh
+++ b/.termux-toolkit/scripts/monitoring/diskwatch.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for diskwatch.sh

--- a/.termux-toolkit/scripts/monitoring/io-analyzer.sh
+++ b/.termux-toolkit/scripts/monitoring/io-analyzer.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for io-analyzer.sh

--- a/.termux-toolkit/scripts/monitoring/port-monitor.sh
+++ b/.termux-toolkit/scripts/monitoring/port-monitor.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for port-monitor.sh

--- a/.termux-toolkit/scripts/monitoring/process-watcher.sh
+++ b/.termux-toolkit/scripts/monitoring/process-watcher.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for process-watcher.sh

--- a/.termux-toolkit/scripts/monitoring/ram-watchdog.sh
+++ b/.termux-toolkit/scripts/monitoring/ram-watchdog.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for ram-watchdog.sh

--- a/.termux-toolkit/scripts/monitoring/resource-check.sh
+++ b/.termux-toolkit/scripts/monitoring/resource-check.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for resource-check.sh

--- a/.termux-toolkit/scripts/monitoring/smart-undo.sh
+++ b/.termux-toolkit/scripts/monitoring/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/monitoring/statuslog.sh
+++ b/.termux-toolkit/scripts/monitoring/statuslog.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for statuslog.sh

--- a/.termux-toolkit/scripts/monitoring/uptime-report.sh
+++ b/.termux-toolkit/scripts/monitoring/uptime-report.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for uptime-report.sh

--- a/.termux-toolkit/scripts/network/dns-debug.sh
+++ b/.termux-toolkit/scripts/network/dns-debug.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for dns-debug.sh

--- a/.termux-toolkit/scripts/network/hotspot-usage.sh
+++ b/.termux-toolkit/scripts/network/hotspot-usage.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for hotspot-usage.sh

--- a/.termux-toolkit/scripts/network/ip-scan.sh
+++ b/.termux-toolkit/scripts/network/ip-scan.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for ip-scan.sh

--- a/.termux-toolkit/scripts/network/local-httpd.sh
+++ b/.termux-toolkit/scripts/network/local-httpd.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for local-httpd.sh

--- a/.termux-toolkit/scripts/network/net-reset.sh
+++ b/.termux-toolkit/scripts/network/net-reset.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for net-reset.sh

--- a/.termux-toolkit/scripts/network/open-hotspot.sh
+++ b/.termux-toolkit/scripts/network/open-hotspot.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for open-hotspot.sh

--- a/.termux-toolkit/scripts/network/ping-check.sh
+++ b/.termux-toolkit/scripts/network/ping-check.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for ping-check.sh

--- a/.termux-toolkit/scripts/network/port-scan.sh
+++ b/.termux-toolkit/scripts/network/port-scan.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for port-scan.sh

--- a/.termux-toolkit/scripts/network/smart-undo.sh
+++ b/.termux-toolkit/scripts/network/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/network/speed-test.sh
+++ b/.termux-toolkit/scripts/network/speed-test.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for speed-test.sh

--- a/.termux-toolkit/scripts/network/wifi-analyzer.sh
+++ b/.termux-toolkit/scripts/network/wifi-analyzer.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for wifi-analyzer.sh

--- a/.termux-toolkit/scripts/productivity/archive-notes.sh
+++ b/.termux-toolkit/scripts/productivity/archive-notes.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for archive-notes.sh

--- a/.termux-toolkit/scripts/productivity/daily-summary.sh
+++ b/.termux-toolkit/scripts/productivity/daily-summary.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for daily-summary.sh

--- a/.termux-toolkit/scripts/productivity/dev-notes.sh
+++ b/.termux-toolkit/scripts/productivity/dev-notes.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for dev-notes.sh

--- a/.termux-toolkit/scripts/productivity/focus-timer.sh
+++ b/.termux-toolkit/scripts/productivity/focus-timer.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for focus-timer.sh

--- a/.termux-toolkit/scripts/productivity/journal.sh
+++ b/.termux-toolkit/scripts/productivity/journal.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for journal.sh

--- a/.termux-toolkit/scripts/productivity/note-audio.sh
+++ b/.termux-toolkit/scripts/productivity/note-audio.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for note-audio.sh

--- a/.termux-toolkit/scripts/productivity/quicklog.sh
+++ b/.termux-toolkit/scripts/productivity/quicklog.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for quicklog.sh

--- a/.termux-toolkit/scripts/productivity/random-prompt.sh
+++ b/.termux-toolkit/scripts/productivity/random-prompt.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for random-prompt.sh

--- a/.termux-toolkit/scripts/productivity/smart-undo.sh
+++ b/.termux-toolkit/scripts/productivity/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/productivity/sync-gdrive.sh
+++ b/.termux-toolkit/scripts/productivity/sync-gdrive.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for sync-gdrive.sh

--- a/.termux-toolkit/scripts/productivity/task-list.sh
+++ b/.termux-toolkit/scripts/productivity/task-list.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for task-list.sh

--- a/.termux-toolkit/scripts/security/activity-sniffer.sh
+++ b/.termux-toolkit/scripts/security/activity-sniffer.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for activity-sniffer.sh

--- a/.termux-toolkit/scripts/security/encrypted-notes.sh
+++ b/.termux-toolkit/scripts/security/encrypted-notes.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for encrypted-notes.sh

--- a/.termux-toolkit/scripts/security/file-locker.sh
+++ b/.termux-toolkit/scripts/security/file-locker.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for file-locker.sh

--- a/.termux-toolkit/scripts/security/firewall-lite.sh
+++ b/.termux-toolkit/scripts/security/firewall-lite.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for firewall-lite.sh

--- a/.termux-toolkit/scripts/security/harden-perms.sh
+++ b/.termux-toolkit/scripts/security/harden-perms.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for harden-perms.sh

--- a/.termux-toolkit/scripts/security/kill-switch.sh
+++ b/.termux-toolkit/scripts/security/kill-switch.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for kill-switch.sh

--- a/.termux-toolkit/scripts/security/session-timer.sh
+++ b/.termux-toolkit/scripts/security/session-timer.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for session-timer.sh

--- a/.termux-toolkit/scripts/security/smart-undo.sh
+++ b/.termux-toolkit/scripts/security/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/security/suspicious-log-check.sh
+++ b/.termux-toolkit/scripts/security/suspicious-log-check.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for suspicious-log-check.sh

--- a/.termux-toolkit/scripts/security/vpn-connect.sh
+++ b/.termux-toolkit/scripts/security/vpn-connect.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for vpn-connect.sh

--- a/.termux-toolkit/scripts/security/wipe-history.sh
+++ b/.termux-toolkit/scripts/security/wipe-history.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for wipe-history.sh

--- a/.termux-toolkit/scripts/system/android-link.sh
+++ b/.termux-toolkit/scripts/system/android-link.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for android-link.sh

--- a/.termux-toolkit/scripts/system/dotfiles-sync.sh
+++ b/.termux-toolkit/scripts/system/dotfiles-sync.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for dotfiles-sync.sh

--- a/.termux-toolkit/scripts/system/full-update.sh
+++ b/.termux-toolkit/scripts/system/full-update.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for full-update.sh

--- a/.termux-toolkit/scripts/system/setup-termux.sh
+++ b/.termux-toolkit/scripts/system/setup-termux.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for setup-termux.sh

--- a/.termux-toolkit/scripts/system/shell-chooser.sh
+++ b/.termux-toolkit/scripts/system/shell-chooser.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for shell-chooser.sh

--- a/.termux-toolkit/scripts/system/smart-undo.sh
+++ b/.termux-toolkit/scripts/system/smart-undo.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for smart-undo.sh

--- a/.termux-toolkit/scripts/system/system-clean.sh
+++ b/.termux-toolkit/scripts/system/system-clean.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for system-clean.sh

--- a/.termux-toolkit/scripts/system/termux-repair.sh
+++ b/.termux-toolkit/scripts/system/termux-repair.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for termux-repair.sh

--- a/.termux-toolkit/scripts/system/toolkit-core.sh
+++ b/.termux-toolkit/scripts/system/toolkit-core.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for toolkit-core.sh

--- a/.termux-toolkit/scripts/system/toolkit-reset.sh
+++ b/.termux-toolkit/scripts/system/toolkit-reset.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for toolkit-reset.sh

--- a/.termux-toolkit/scripts/system/tty-switcher.sh
+++ b/.termux-toolkit/scripts/system/tty-switcher.sh
@@ -1,0 +1,2 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# placeholder for tty-switcher.sh


### PR DESCRIPTION
## Summary
- scaffold `.termux-toolkit` directory
- add placeholder executables for toolkit commands
- include initial assets and man directory

## Testing
- `bash scripts/test/test-network.sh` *(fails: network unreachable)*
- `bash scripts/test/test-storage-access.sh`
- `bash scripts/test/test-script.sh .termux-toolkit/scripts/system/full-update.sh` *(fails: returned error)*

------
https://chatgpt.com/codex/tasks/task_e_685ed27dbc04833394babf44629ed8f4