### PR TITLE
Add network utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The project is currently in **v1.0-alpha**.
 - 🛠 **files**: `move-files`, `batch-rename`
 - 🔒 **security**: `backup-data`, `antivirus-scan`
 - 🧑‍💻 **dev**: `newproject`
+- 🌐 **network**: `ping-check`, `dns-debug`
 
 See the [blog post](https://example.com) for details.
 

--- a/man/network/dns-debug.man
+++ b/man/network/dns-debug.man
@@ -1,0 +1,4 @@
+dns-debug - resolve domains for troubleshooting
+
+Usage:
+  dns-debug [--offline] <domain1> [domain2 ...]

--- a/man/network/net-reset.man
+++ b/man/network/net-reset.man
@@ -1,0 +1,4 @@
+net-reset - restart Wi-Fi interface
+
+Usage:
+  net-reset [--offline]

--- a/man/network/ping-check.man
+++ b/man/network/ping-check.man
@@ -1,0 +1,4 @@
+ping-check - ping hosts and report latency
+
+Usage:
+  ping-check [--offline] <host1> [host2 ...]

--- a/man/network/port-scan.man
+++ b/man/network/port-scan.man
@@ -1,0 +1,4 @@
+port-scan - scan host ports with nmap
+
+Usage:
+  port-scan [--offline] <host> [ports]

--- a/man/network/speed-test.man
+++ b/man/network/speed-test.man
@@ -1,0 +1,4 @@
+speed-test - measure download speed
+
+Usage:
+  speed-test [--offline] [url]

--- a/scripts/network/dns-debug.sh
+++ b/scripts/network/dns-debug.sh
@@ -1,0 +1,49 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Description: diagnose DNS resolution for domains
+# Dependencies: bind-utils
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+usage() {
+  echo "dns-debug - resolve domains and output records";
+  echo "Usage: dns-debug [--offline] <domain1> [domain2 ...]";
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+offline=false
+domains=()
+for arg in "$@"; do
+  case $arg in
+    --offline) offline=true ;;
+    *) domains+=("$arg") ;;
+  esac
+  shift || true
+done
+
+[[ ${#domains[@]} -gt 0 ]] || domains=("google.com")
+
+if $offline; then
+  log_warn "Offline mode - checking /etc/hosts only"
+  for d in "${domains[@]}"; do
+    grep -w "$d" /etc/hosts || log_warn "$d not found in hosts"
+  done
+  exit 0
+fi
+
+require_tool nslookup bind-utils || require_tool dig dnsutils || exit 1
+
+LOG_DIR="$HOME/.termux-toolkit/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/dns-debug.log"
+
+for d in "${domains[@]}"; do
+  log_info "Querying $d..."
+  nslookup "$d" | tee -a "$LOG_FILE" || log_warn "Failed to resolve $d" | tee -a "$LOG_FILE"
+  sleep 1
+done

--- a/scripts/network/net-reset.sh
+++ b/scripts/network/net-reset.sh
@@ -1,0 +1,39 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Description: toggle Wi-Fi off and on to refresh network
+# Dependencies: termux-api
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+usage() {
+  echo "net-reset - restart Wi-Fi interface";
+  echo "Usage: net-reset [--offline]";
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+offline=false
+for arg in "$@"; do
+  case $arg in
+    --offline) offline=true ;;
+  esac
+  shift || true
+done
+
+if $offline; then
+  log_warn "Offline mode - skipping network reset"
+  exit 0
+fi
+
+require_tool termux-wifi-enable termux-api || exit 1
+
+log_info "Disabling Wi-Fi..."
+termux-wifi-enable false >/dev/null 2>&1 || log_warn "Failed to disable"
+sleep 2
+log_info "Enabling Wi-Fi..."
+termux-wifi-enable true >/dev/null 2>&1 || log_warn "Failed to enable"
+log_info "Wi-Fi toggled"

--- a/scripts/network/ping-check.sh
+++ b/scripts/network/ping-check.sh
@@ -1,0 +1,51 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Description: ping one or more hosts and report latency
+# Dependencies: iputils-ping
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+usage() {
+  echo "ping-check - ping hosts";
+  echo "Usage: ping-check [--offline] <host1> [host2 ...]";
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+offline=false
+hosts=()
+for arg in "$@"; do
+  case $arg in
+    --offline) offline=true ;;
+    *) hosts+=("$arg") ;;
+  esac
+  shift || true
+done
+
+[[ ${#hosts[@]} -gt 0 ]] || hosts=("1.1.1.1" "google.com")
+
+if $offline; then
+  log_warn "Offline mode - skipping network pings"
+  exit 0
+fi
+
+require_tool ping iputils-ping || exit 1
+
+LOG_DIR="$HOME/.termux-toolkit/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/ping-check.log"
+
+for h in "${hosts[@]}"; do
+  log_info "Pinging $h..."
+  if ping -c1 "$h" >/dev/null 2>&1; then
+    latency=$(ping -c1 "$h" | awk -F'/' 'END{print $5" ms"}')
+    log_info "$h responded in $latency" | tee -a "$LOG_FILE"
+  else
+    log_warn "$h unreachable" | tee -a "$LOG_FILE"
+  fi
+  sleep 1
+done

--- a/scripts/network/port-scan.sh
+++ b/scripts/network/port-scan.sh
@@ -1,0 +1,45 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Description: scan ports on a host using nmap
+# Dependencies: nmap
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+usage() {
+  echo "port-scan - simple port scanner";
+  echo "Usage: port-scan [--offline] <host> [ports]";
+  echo "Example: port-scan 192.168.1.1 22,80";
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+offline=false
+host=""
+ports="1-1024"
+for arg in "$@"; do
+  case $arg in
+    --offline) offline=true ;;
+    *) if [[ -z $host ]]; then host="$arg"; else ports="$arg"; fi ;;
+  esac
+  shift || true
+done
+
+[[ -n $host ]] || { usage; exit 1; }
+
+if $offline; then
+  log_warn "Offline mode - skipping port scan"
+  exit 0
+fi
+
+require_tool nmap nmap || exit 1
+
+LOG_DIR="$HOME/.termux-toolkit/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/port-scan.log"
+
+log_info "Scanning $host ports $ports..."
+nmap -p "$ports" "$host" | tee "$LOG_FILE"

--- a/scripts/network/speed-test.sh
+++ b/scripts/network/speed-test.sh
@@ -1,0 +1,52 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Description: measure network download speed using curl
+# Dependencies: curl
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+usage() {
+  echo "speed-test - quick bandwidth test";
+  echo "Usage: speed-test [--offline] [url]";
+  echo "Default URL: https://speed.hetzner.de/100MB.bin";
+}
+
+if [[ ${1:-} == "-h" || ${1:-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+offline=false
+url="https://speed.hetzner.de/100MB.bin"
+for arg in "$@"; do
+  case $arg in
+    --offline) offline=true ;;
+    *) url="$arg" ;;
+  esac
+  shift || true
+done
+
+if $offline; then
+  log_warn "Offline mode - skipping speed test"
+  exit 0
+fi
+
+require_tool curl curl || exit 1
+check_network || exit 1
+
+TMP_FILE=$(mktemp)
+log_info "Downloading test file..."
+start=$(date +%s)
+curl -L "$url" -o "$TMP_FILE" --progress-bar >/dev/null
+end=$(date +%s)
+rm -f "$TMP_FILE"
+
+elapsed=$((end - start))
+if [[ $elapsed -gt 0 ]]; then
+  size_mb=100
+  rate=$((size_mb / elapsed))
+  log_info "Approx speed: ${rate} MB/s"
+else
+  log_warn "Test too quick to measure"
+fi


### PR DESCRIPTION
## Summary
- add network utilities scripts (`ping-check`, `dns-debug`, `speed-test`, `port-scan`, `net-reset`)
- document new utilities in `man/network`
- mention network tools in README

## Testing
- `bash scripts/test/test-storage-access.sh`
- `bash scripts/test/test-network.sh`
- `bash scripts/test/test-script.sh scripts/network/ping-check.sh` *(fails: returned error)*

------
https://chatgpt.com/codex/tasks/task_e_685f6cb79368833391bd418d96d1169a