### PR TITLE
Add clearer manuals and a Solace integration interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,33 @@ plugins and logs after confirmation.
 ## Usage
 Run `mini-man` to list all tools. Each command has `-h` or `--help`.
 
+The manual browser can be opened in any of these equivalent ways:
+
+```bash
+mini-man
+mini man
+ttk man
+```
+
+Use `ttk help` for examples, `ttk man <category> <tool>` to read a manual,
+or `ttk list` to print every installed command.
+
+### Integration with other assistants
+
+Other local programs such as Solace should integrate through the stable `ttk`
+interface rather than reading toolkit internals directly:
+
+```bash
+command -v ttk                 # detect the installation
+ttk root                       # locate the installed toolkit
+ttk version                    # read its version
+ttk list                       # discover available commands
+ttk has move-files             # test a capability using the exit status
+ttk run move-files --help      # safely invoke a toolkit command
+```
+
+This keeps integrations working if the toolkit's internal folders change.
+
 ### Security Module
 Run `mini-man security` to view commands such as malware scans, backups and network checks.
 

--- a/man/mini.man
+++ b/man/mini.man
@@ -1,0 +1,12 @@
+mini - friendly manual shortcut
+
+USAGE
+  mini man [category] [tool]
+
+DESCRIPTION
+  Opens the same toolkit manuals as mini-man and ttk man.
+
+EXAMPLES
+  mini man
+  mini man files
+  mini man files move-files

--- a/scripts/system/mini.sh
+++ b/scripts/system/mini.sh
@@ -1,0 +1,29 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+mini - friendly shortcut for mini-man
+
+Usage:
+  mini man [category] [tool]
+
+Examples:
+  mini man
+  mini man files
+  mini man files move-files
+EOF
+}
+
+case ${1:-} in
+  man)
+    shift
+    exec bash "$(command -v mini-man)" "$@"
+    ;;
+  -h|--help|"") usage ;;
+  *)
+    echo "Unknown mini command: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/system/ttk.sh
+++ b/scripts/system/ttk.sh
@@ -2,6 +2,45 @@
 set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+TOOLKIT_HOME="$HOME/.termux-toolkit"
+TOOLKIT_BIN="$TOOLKIT_HOME/bin"
+
+usage() {
+  cat <<'EOF'
+Termux Toolkit (ttk)
+
+Usage:
+  ttk help                         Show this help
+  ttk man [category] [tool]        List or read manuals
+  ttk list                         List installed toolkit commands
+  ttk has <tool>                   Check whether a tool is installed
+  ttk run <tool> [arguments...]    Run an installed toolkit tool
+  ttk root                         Print the toolkit installation path
+  ttk version                      Print the installed version
+  ttk status                       Show package-batch status
+  ttk scan [path...]               Run the antivirus tool
+  ttk update                       Update from the original Git clone
+  ttk install                      Reinstall from the original Git clone
+
+Manual examples:
+  ttk man                          List all manuals and categories
+  ttk man files                    List file-tool manuals
+  ttk man files move-files         Read the move-files manual
+
+You can also use `mini-man` or `mini man` instead of `ttk man`.
+
+Integration examples:
+  command -v ttk                   Detect whether the toolkit is installed
+  ttk has move-files               Check for a capability
+  ttk run move-files --help        Run a tool through the stable interface
+EOF
+}
+
+valid_tool_name() {
+  [[ $1 =~ ^[a-z0-9][a-z0-9-]*$ ]]
+}
+
 cmd=${1:-help}
 shift || true
 case $cmd in
@@ -14,8 +53,39 @@ case $cmd in
     "$source_dir/install-toolkit.sh" "$@"
     ;;
   man) mini-man "$@" ;;
+  list)
+    find "$TOOLKIT_BIN" -mindepth 1 -maxdepth 1 -type f -printf '%f\n' \
+      | grep -vE '^(ttk|uninstall-toolkit)$' | sort
+    ;;
+  has)
+    [[ $# -eq 1 ]] || { echo "Usage: ttk has <tool>" >&2; exit 2; }
+    valid_tool_name "$1" && [[ -x "$TOOLKIT_BIN/$1" ]]
+    ;;
+  run)
+    [[ $# -ge 1 ]] || { echo "Usage: ttk run <tool> [arguments...]" >&2; exit 2; }
+    tool=$1
+    shift
+    valid_tool_name "$tool" || { log_error "Invalid tool name: $tool"; exit 2; }
+    [[ $tool != "ttk" && $tool != "uninstall-toolkit" ]] || {
+      log_error "'$tool' cannot be run through ttk run."
+      exit 2
+    }
+    [[ -x "$TOOLKIT_BIN/$tool" ]] || {
+      log_error "Toolkit command '$tool' is not installed. Run 'ttk list' to see available commands."
+      exit 127
+    }
+    exec bash "$TOOLKIT_BIN/$tool" "$@"
+    ;;
+  root) printf '%s\n' "$TOOLKIT_HOME" ;;
+  version) cat "$TOOLKIT_HOME/VERSION" ;;
   status) pkg-toolkit --status ;;
   scan) antivirus-scan "$@" ;;
   update) ttk-update ;;
-  help|*) echo "ttk <install|man|status|scan|update>" ;;
+  help|-h|--help) usage ;;
+  *)
+    log_error "Unknown ttk command: $cmd"
+    echo
+    usage
+    exit 2
+    ;;
 esac

--- a/tests/install-smoke.sh
+++ b/tests/install-smoke.sh
@@ -21,14 +21,29 @@ bash "$REPO_ROOT/install-toolkit.sh"
 
 [[ -x "$PREFIX/bin/ttk" ]]
 [[ -x "$PREFIX/bin/mini-man" ]]
+[[ -x "$PREFIX/bin/mini" ]]
 [[ -x "$PREFIX/bin/pkg-toolkit" ]]
 [[ -f "$HOME/.termux-toolkit/scripts/security/security-common.sh" ]]
 [[ ! -e "$HOME/.bashrc" ]]
 
-bash "$PREFIX/bin/ttk" help | grep -q 'ttk <install|man|status|scan|update>'
-bash "$PREFIX/bin/mini-man" --help | grep -q 'Usage:'
-bash "$PREFIX/bin/pkg-toolkit" --list | grep -q 'dev:'
-bash "$PREFIX/bin/antivirus-scan" --help | grep -q 'Usage:'
+help_output=$(bash "$PREFIX/bin/ttk" help)
+grep -q 'ttk man \[category\] \[tool\]' <<< "$help_output"
+mini_help=$(bash "$PREFIX/bin/mini-man" --help)
+grep -q 'Usage:' <<< "$mini_help"
+manuals=$(bash "$PREFIX/bin/mini" man)
+grep -q 'Available manuals:' <<< "$manuals"
+package_list=$(bash "$PREFIX/bin/pkg-toolkit" --list)
+grep -q 'dev:' <<< "$package_list"
+scan_help=$(bash "$PREFIX/bin/antivirus-scan" --help)
+grep -q 'Usage:' <<< "$scan_help"
+tool_list=$(bash "$PREFIX/bin/ttk" list)
+grep -qx 'move-files' <<< "$tool_list"
+bash "$PREFIX/bin/ttk" has move-files
+! bash "$PREFIX/bin/ttk" has missing-tool
+[[ $(bash "$PREFIX/bin/ttk" root) == "$HOME/.termux-toolkit" ]]
+[[ $(bash "$PREFIX/bin/ttk" version) == "v1.0-alpha" ]]
+run_help=$(bash "$PREFIX/bin/ttk" run antivirus-scan --help)
+grep -q 'Usage:' <<< "$run_help"
 
 # Reinstallation should remain idempotent and preserve user-owned data.
 printf '%s\n' 'custom=true' > "$HOME/.termux-toolkit/config"


### PR DESCRIPTION
## Summary
- expand `ttk help` with command descriptions and practical manual examples
- support all three manual entry points: `mini-man`, `mini man`, and `ttk man`
- add stable discovery commands for local assistants and other programs
- add safe toolkit command execution through `ttk run`
- document the supported Solace integration contract

## Integration interface
- `command -v ttk` — detect installation
- `ttk root` — locate the installed toolkit
- `ttk version` — inspect the installed version
- `ttk list` — discover available commands
- `ttk has <tool>` — check a capability by exit status
- `ttk run <tool> [args...]` — safely run an installed tool

Tool names are validated, unavailable tools return a useful error, and lifecycle commands cannot be invoked through `ttk run`.

## Verification
- all Bash files pass syntax validation
- isolated installation and reinstallation tests pass
- `mini man` opens the manual browser
- discovery, capability checking, version/root lookup, and command execution pass
- uninstallation checks still pass
- `git diff --check` passes