### PR TITLE
Add website project discovery and browser tools

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -26,3 +26,5 @@ jobs:
           shellcheck --severity=error -x -e SC1090,SC1091 "${files[@]}"
       - name: Test installation
         run: bash tests/install-smoke.sh
+      - name: Test website tools
+        run: bash tests/website-tools.sh

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The project is currently in **v1.0-alpha**.
 - 🔒 **security**: `backup-data`, `antivirus-scan`
 - 🧑‍💻 **dev**: `newproject`
 - 🌐 **network**: `ping-check`, `dns-debug`
+- 🌍 **website projects**: `project-find`, `project-info`, `site-open`, `site-status`, `site-stop`
 
 ## Installation
 ```bash
@@ -64,6 +65,26 @@ ttk run move-files --help      # safely invoke a toolkit command
 ```
 
 This keeps integrations working if the toolkit's internal folders change.
+
+### Open a website project from device storage
+
+`site-open` can find a project folder or ZIP by name, safely extract ZIP files,
+identify common web stacks, start the appropriate local development server and
+open it in the Android browser:
+
+```bash
+project-find "client website"
+project-info "client website"
+site-open "client website"
+site-status
+site-stop
+```
+
+Supported detection includes static HTML, PHP, Vite, Next.js, Create React App,
+Angular, Astro, Nuxt and generic Node.js projects. Unknown project code is not
+executed silently: missing JavaScript dependencies require confirmation before
+the package manager is run. Use `site-open <name> --dry-run` to inspect the
+detected project and launch command without starting anything.
 
 ### Security Module
 Run `mini-man security` to view commands such as malware scans, backups and network checks.

--- a/install-toolkit.sh
+++ b/install-toolkit.sh
@@ -52,7 +52,7 @@ EOF
 while IFS= read -r script; do
   name="$(basename "$script")"
   name="${name%.sh}"
-  [[ $name == "toolkit-core" || $name == "security-common" ]] && continue
+  [[ $name == "toolkit-core" || $name == *-common ]] && continue
   create_launcher "$name" "$script"
 done < <(find "$TARGET/scripts" -mindepth 2 -maxdepth 2 -type f \
   \( -name '*.sh' -o -name 'mini-man' \) ! -path '*/test/*' | sort)

--- a/man/dev/project-find.man
+++ b/man/dev/project-find.man
@@ -1,0 +1,12 @@
+project-find - locate project folders and ZIP archives
+
+USAGE
+  project-find <name> [--root <directory>]
+
+DESCRIPTION
+  Searches Termux home and shared device storage by default. Results exclude
+  .git, node_modules and the toolkit's private runtime folder.
+
+EXAMPLES
+  project-find "client website"
+  project-find portfolio --root ~/storage/shared/Download

--- a/man/dev/project-info.man
+++ b/man/dev/project-info.man
@@ -1,0 +1,13 @@
+project-info - inspect a local website project
+
+USAGE
+  project-info <folder-or-zip-or-name> [--root <directory>]
+
+DESCRIPTION
+  Resolves a path or searches storage, safely extracts ZIP archives, and reports
+  the detected technology stack, package manager, entry point and dependency
+  status. It does not execute the project.
+
+EXAMPLES
+  project-info ~/storage/shared/Download/portfolio.zip
+  project-info "client website"

--- a/man/dev/site-open.man
+++ b/man/dev/site-open.man
@@ -1,0 +1,20 @@
+site-open - find, analyse, serve and open a website project
+
+USAGE
+  site-open <folder-or-zip-or-name> [options]
+
+OPTIONS
+  --root <directory>  Limit name searching to one directory.
+  --port <number>     Select a local port; default is 4173.
+  --no-open           Do not open the Android browser.
+  --dry-run           Show detection and the launch command only.
+
+SAFETY
+  ZIP entries containing absolute paths or parent traversal are rejected.
+  JavaScript dependencies are only installed after confirmation. Use --dry-run
+  before opening an unfamiliar project.
+
+EXAMPLES
+  site-open "client website"
+  site-open ~/storage/shared/Download/site.zip --port 8080
+  site-open portfolio --dry-run

--- a/man/dev/site-status.man
+++ b/man/dev/site-status.man
@@ -1,0 +1,7 @@
+site-status - show the website server started by site-open
+
+USAGE
+  site-status
+
+DESCRIPTION
+  Prints the server PID, project folder, local URL and log location.

--- a/man/dev/site-stop.man
+++ b/man/dev/site-stop.man
@@ -1,0 +1,7 @@
+site-stop - stop the website server started by site-open
+
+USAGE
+  site-stop
+
+DESCRIPTION
+  Stops only the process recorded by the toolkit's website server state.

--- a/scripts/dev/project-find.sh
+++ b/scripts/dev/project-find.sh
@@ -1,0 +1,22 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+usage() {
+  echo "Usage: project-find <name> [--root <directory>]"
+}
+
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+[[ $# -ge 1 ]] || { usage >&2; exit 2; }
+query=$1
+shift
+root=""
+while (($#)); do
+  case $1 in
+    --root) root="${2:-}"; shift 2 ;;
+    *) log_error "Unknown option: $1"; exit 2 ;;
+  esac
+done
+
+website_find "$query" "$root" | awk '!seen[$0]++'

--- a/scripts/dev/project-info.sh
+++ b/scripts/dev/project-info.sh
@@ -1,0 +1,31 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+usage() {
+  echo "Usage: project-info <folder-or-zip-or-name> [--root <directory>]"
+}
+
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+[[ $# -ge 1 ]] || { usage >&2; exit 2; }
+value=$1
+shift
+root=""
+while (($#)); do
+  case $1 in
+    --root) root="${2:-}"; shift 2 ;;
+    *) log_error "Unknown option: $1"; exit 2 ;;
+  esac
+done
+
+project="$(website_resolve_project "$value" "$root")"
+stack="$(website_stack "$project")"
+manager="$(website_package_manager "$project")"
+
+printf 'Project: %s\nStack: %s\nPackage manager: %s\n' "$project" "$stack" "$manager"
+[[ -f "$project/package.json" ]] && echo "Manifest: package.json"
+[[ -f "$project/index.html" ]] && echo "Entry point: index.html"
+[[ -d "$project/node_modules" ]] && echo "Dependencies: installed" || {
+  [[ $manager == none ]] || echo "Dependencies: not installed"
+}

--- a/scripts/dev/site-open.sh
+++ b/scripts/dev/site-open.sh
@@ -1,0 +1,127 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: site-open <folder-or-zip-or-name> [options]
+
+Options:
+  --root <directory>  Limit name searching to one directory
+  --port <number>     Local port (default: 4173)
+  --no-open           Start the server without opening a browser
+  --dry-run           Show what would happen without running anything
+EOF
+}
+
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+[[ $# -ge 1 ]] || { usage >&2; exit 2; }
+value=$1
+shift
+root="" port=4173 open_browser=true dry_run=false
+while (($#)); do
+  case $1 in
+    --root) root="${2:-}"; shift 2 ;;
+    --port) port="${2:-}"; shift 2 ;;
+    --no-open) open_browser=false; shift ;;
+    --dry-run) dry_run=true; shift ;;
+    *) log_error "Unknown option: $1"; exit 2 ;;
+  esac
+done
+[[ $port =~ ^[0-9]+$ && $port -ge 1024 && $port -le 65535 ]] || {
+  log_error "Port must be between 1024 and 65535."
+  exit 2
+}
+if command -v ss >/dev/null 2>&1 && ss -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "(^|:)$port$"; then
+  log_error "Port $port is already in use. Choose another with --port."
+  exit 1
+fi
+
+project="$(website_resolve_project "$value" "$root")"
+stack="$(website_stack "$project")"
+manager="$(website_package_manager "$project")"
+url="http://127.0.0.1:$port"
+declare -a command
+
+case $stack in
+  "Next.js") command=("$manager" run dev -- --hostname 127.0.0.1 --port "$port") ;;
+  Vite|Astro|Nuxt|Angular|Node.js) command=("$manager" run dev -- --host 127.0.0.1 --port "$port") ;;
+  "Create React App") command=(env HOST=127.0.0.1 PORT="$port" "$manager" start) ;;
+  PHP) command=(php -S "127.0.0.1:$port" -t "$project") ;;
+  "Static HTML") command=(python -m http.server "$port" --bind 127.0.0.1 --directory "$project") ;;
+  *) log_error "Could not determine how to serve this project. Run project-info first."; exit 1 ;;
+esac
+
+log_info "Project: $project"
+log_info "Detected stack: $stack"
+log_info "URL: $url"
+printf 'Command:'; printf ' %q' "${command[@]}"; echo
+[[ $dry_run == true ]] && exit 0
+
+if [[ $manager != none && ! -d "$project/node_modules" ]]; then
+  ask_confirm "Dependencies are missing. Run '$manager install' in this project?" || {
+    log_warn "Cancelled before executing project code."
+    exit 1
+  }
+  (cd "$project" && "$manager" install)
+fi
+
+case $stack in
+  PHP) require_tool php php || exit 1 ;;
+  "Static HTML") require_tool python python || exit 1 ;;
+  *) require_tool "$manager" "$manager" || exit 1 ;;
+esac
+
+mkdir -p "$WEBSITE_STATE_DIR"
+old_pid="$(cat "$WEBSITE_STATE_DIR/server.pid" 2>/dev/null || true)"
+if website_pid_matches "$old_pid"; then
+  log_error "A toolkit website server is already running (PID $old_pid). Run site-stop first."
+  exit 1
+fi
+log_file="$WEBSITE_STATE_DIR/server.log"
+starting_dir="$PWD"
+cd "$project"
+nohup "${command[@]}" >"$log_file" 2>&1 &
+pid=$!
+cd "$starting_dir"
+printf '%s\n' "$pid" > "$WEBSITE_STATE_DIR/server.pid"
+printf '%s\n' "$project" > "$WEBSITE_STATE_DIR/project"
+printf '%s\n' "$url" > "$WEBSITE_STATE_DIR/url"
+
+sleep 1
+kill -0 "$pid" 2>/dev/null || {
+  log_error "Server stopped during startup. Last log lines:"
+  tail -20 "$log_file" >&2
+  exit 1
+}
+start_time="$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true)"
+if [[ -z $start_time ]]; then
+  log_error "Server stopped during startup. Last log lines:"
+  tail -20 "$log_file" >&2
+  exit 1
+fi
+printf '%s\n' "$start_time" > "$WEBSITE_STATE_DIR/server.start"
+
+if command -v curl >/dev/null 2>&1; then
+  ready=false
+  for _ in {1..15}; do
+    if curl -fsS --max-time 1 "$url" >/dev/null 2>&1; then
+      ready=true
+      break
+    fi
+    kill -0 "$pid" 2>/dev/null || break
+    sleep 1
+  done
+  [[ $ready == true ]] || log_warn "Server is running but did not respond yet. Check site-status and the log."
+fi
+
+log_success "Website server started (PID $pid)."
+if [[ $open_browser == true ]]; then
+  if command -v termux-open-url >/dev/null 2>&1; then
+    termux-open-url "$url"
+  else
+    log_warn "termux-open-url is unavailable. Open $url manually."
+  fi
+fi
+echo "Run 'site-status' for details or 'site-stop' when finished."

--- a/scripts/dev/site-status.sh
+++ b/scripts/dev/site-status.sh
@@ -1,0 +1,20 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+[[ ${1:-} == -h || ${1:-} == --help ]] && {
+  echo "Usage: site-status"
+  exit 0
+}
+
+pid="$(cat "$WEBSITE_STATE_DIR/server.pid" 2>/dev/null || true)"
+website_pid_matches "$pid" || {
+  echo "No toolkit website server is running."
+  exit 1
+}
+echo "Status: running"
+echo "PID: $pid"
+echo "Project: $(cat "$WEBSITE_STATE_DIR/project")"
+echo "URL: $(cat "$WEBSITE_STATE_DIR/url")"
+echo "Log: $WEBSITE_STATE_DIR/server.log"

--- a/scripts/dev/site-stop.sh
+++ b/scripts/dev/site-stop.sh
@@ -1,0 +1,20 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+[[ ${1:-} == -h || ${1:-} == --help ]] && {
+  echo "Usage: site-stop"
+  exit 0
+}
+
+pid="$(cat "$WEBSITE_STATE_DIR/server.pid" 2>/dev/null || true)"
+[[ -n $pid && $pid =~ ^[0-9]+$ ]] || { echo "No recorded website server."; exit 1; }
+if website_pid_matches "$pid"; then
+  kill "$pid"
+  log_success "Stopped website server (PID $pid)."
+else
+  echo "Recorded server is no longer running; no process was stopped."
+fi
+rm -f "$WEBSITE_STATE_DIR/server.pid" "$WEBSITE_STATE_DIR/server.start" \
+  "$WEBSITE_STATE_DIR/url" "$WEBSITE_STATE_DIR/project"

--- a/scripts/dev/website-common.sh
+++ b/scripts/dev/website-common.sh
@@ -1,0 +1,131 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+WEBSITE_STATE_DIR="$HOME/.termux-toolkit/state/website"
+WEBSITE_WORK_DIR="$HOME/.termux-toolkit/workspaces/websites"
+
+website_search_roots() {
+  [[ -d "$HOME/storage/shared" ]] && printf '%s\n' "$HOME/storage/shared"
+  printf '%s\n' "$HOME"
+}
+
+website_find() {
+  local query="$1" root="${2:-}" search_root
+  if [[ -n $root ]]; then
+    [[ -d $root ]] || { log_error "Search root does not exist: $root"; return 1; }
+    find "$root" \
+      \( -path '*/.git' -o -path '*/node_modules' -o -path '*/.termux-toolkit' \) -prune -o \
+      \( -type d -o -type f -iname '*.zip' \) -iname "*$query*" -print
+    return
+  fi
+  while IFS= read -r search_root; do
+    find "$search_root" \
+      \( -path '*/.git' -o -path '*/node_modules' -o -path '*/.termux-toolkit' \) -prune -o \
+      \( -type d -o -type f -iname '*.zip' \) -iname "*$query*" -print 2>/dev/null
+  done < <(website_search_roots)
+}
+
+website_choose_match() {
+  local query="$1" root="${2:-}" choice
+  local -a matches=()
+  while IFS= read -r match; do
+    [[ -n $match ]] && matches+=("$match")
+  done < <(website_find "$query" "$root" | awk '!seen[$0]++')
+
+  ((${#matches[@]})) || { log_error "No folder or ZIP matching '$query' was found."; return 1; }
+  if ((${#matches[@]} == 1)); then
+    printf '%s\n' "${matches[0]}"
+    return
+  fi
+  if [[ ! -t 0 ]]; then
+    log_error "Multiple matches found. Pass an exact path instead."
+    printf ' - %s\n' "${matches[@]}" >&2
+    return 1
+  fi
+  echo "Matches:" >&2
+  select choice in "${matches[@]}"; do
+    [[ -n $choice ]] && { printf '%s\n' "$choice"; return; }
+    echo "Choose a listed number." >&2
+  done
+}
+
+website_safe_extract() {
+  local archive="$1" destination base
+  require_tool unzip unzip >&2 || return 1
+  if unzip -Z1 "$archive" | grep -Eq '(^/|(^|/)\.\.(/|$))'; then
+    log_error "Archive contains unsafe paths and was not extracted."
+    return 1
+  fi
+  base="$(basename "${archive%.zip}")"
+  destination="$WEBSITE_WORK_DIR/${base}-$(date +%Y%m%d-%H%M%S)"
+  mkdir -p "$destination"
+  unzip -q "$archive" -d "$destination"
+
+  local -a children=("$destination"/*)
+  if ((${#children[@]} == 1)) && [[ -d ${children[0]} ]]; then
+    printf '%s\n' "${children[0]}"
+  else
+    printf '%s\n' "$destination"
+  fi
+}
+
+website_pid_matches() {
+  local pid="$1" recorded_start current_start
+  [[ $pid =~ ^[0-9]+$ && -r "/proc/$pid/stat" && -f "$WEBSITE_STATE_DIR/server.start" ]] || return 1
+  recorded_start="$(cat "$WEBSITE_STATE_DIR/server.start")"
+  current_start="$(awk '{print $22}' "/proc/$pid/stat" 2>/dev/null || true)"
+  [[ -n $recorded_start && $current_start == "$recorded_start" ]]
+}
+
+website_resolve_project() {
+  local value="$1" root="${2:-}" selected
+  if [[ -e $value ]]; then
+    selected="$(realpath "$value")"
+  else
+    selected="$(website_choose_match "$value" "$root")" || return 1
+  fi
+  if [[ -f $selected && ${selected,,} == *.zip ]]; then
+    website_safe_extract "$selected"
+  elif [[ -d $selected ]]; then
+    printf '%s\n' "$selected"
+  else
+    log_error "Not a website folder or ZIP archive: $selected"
+    return 1
+  fi
+}
+
+website_stack() {
+  local dir="$1" package="${1%/}/package.json"
+  if [[ -f "$dir/next.config.js" || -f "$dir/next.config.mjs" || -f "$dir/next.config.ts" ]]; then
+    echo "Next.js"
+  elif [[ -f "$dir/vite.config.js" || -f "$dir/vite.config.ts" || -f "$dir/vite.config.mjs" ]]; then
+    echo "Vite"
+  elif [[ -f $package ]] && grep -q 'react-scripts' "$package"; then
+    echo "Create React App"
+  elif [[ -f "$dir/angular.json" ]]; then
+    echo "Angular"
+  elif [[ -f "$dir/astro.config.mjs" || -f "$dir/astro.config.ts" ]]; then
+    echo "Astro"
+  elif [[ -f "$dir/nuxt.config.js" || -f "$dir/nuxt.config.ts" ]]; then
+    echo "Nuxt"
+  elif [[ -f $package ]]; then
+    echo "Node.js"
+  elif [[ -f "$dir/index.php" ]]; then
+    echo "PHP"
+  elif [[ -f "$dir/index.html" ]]; then
+    echo "Static HTML"
+  else
+    echo "Unknown"
+  fi
+}
+
+website_package_manager() {
+  local dir="$1"
+  [[ -f "$dir/pnpm-lock.yaml" ]] && { echo pnpm; return; }
+  [[ -f "$dir/yarn.lock" ]] && { echo yarn; return; }
+  [[ -f "$dir/bun.lockb" || -f "$dir/bun.lock" ]] && { echo bun; return; }
+  [[ -f "$dir/package.json" ]] && { echo npm; return; }
+  echo none
+}

--- a/tests/install-smoke.sh
+++ b/tests/install-smoke.sh
@@ -23,6 +23,8 @@ bash "$REPO_ROOT/install-toolkit.sh"
 [[ -x "$PREFIX/bin/mini-man" ]]
 [[ -x "$PREFIX/bin/mini" ]]
 [[ -x "$PREFIX/bin/pkg-toolkit" ]]
+[[ -x "$PREFIX/bin/site-open" ]]
+[[ ! -e "$PREFIX/bin/website-common" ]]
 [[ -f "$HOME/.termux-toolkit/scripts/security/security-common.sh" ]]
 [[ ! -e "$HOME/.bashrc" ]]
 

--- a/tests/website-tools.sh
+++ b/tests/website-tools.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="$TEST_ROOT/home"
+export PREFIX="$TEST_ROOT/prefix"
+export PATH="$PREFIX/bin:/usr/bin:/bin:$PATH"
+mkdir -p "$HOME" "$PREFIX/bin" "$TEST_ROOT/projects/My Portfolio"
+printf '<!doctype html><title>Test</title>\n' > "$TEST_ROOT/projects/My Portfolio/index.html"
+
+cat > "$PREFIX/bin/pkg" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$PREFIX/bin/pkg"
+
+bash "$REPO_ROOT/install-toolkit.sh" >/dev/null
+
+matches=$(bash "$PREFIX/bin/project-find" Portfolio --root "$TEST_ROOT/projects")
+grep -q 'My Portfolio' <<< "$matches"
+
+info=$(bash "$PREFIX/bin/project-info" "$TEST_ROOT/projects/My Portfolio")
+grep -q 'Stack: Static HTML' <<< "$info"
+
+preview=$(bash "$PREFIX/bin/site-open" "$TEST_ROOT/projects/My Portfolio" --dry-run --port 8080)
+grep -q 'Detected stack: Static HTML' <<< "$preview"
+grep -q 'http.server 8080' <<< "$preview"
+
+
+python - "$TEST_ROOT/projects/unsafe.zip" <<'PY'
+import sys
+import zipfile
+
+with zipfile.ZipFile(sys.argv[1], "w") as archive:
+    archive.writestr("../escape.txt", "unsafe")
+PY
+
+if bash "$PREFIX/bin/project-info" "$TEST_ROOT/projects/unsafe.zip" >/dev/null 2>&1; then
+  echo "Unsafe ZIP was unexpectedly accepted" >&2
+  exit 1
+fi
+[[ ! -e "$TEST_ROOT/projects/escape.txt" ]]
+
+echo "Website tool tests passed"


### PR DESCRIPTION
## Summary
Adds a cohesive set of commands for finding website projects in Android storage, inspecting their technology, safely extracting ZIP archives, starting the appropriate local server, and opening it in the browser.

## New commands
- `project-find <name> [--root <dir>]` — search Termux home and shared device storage for matching folders or ZIPs
- `project-info <path-or-name>` — safely resolve/extract a project and report its stack, package manager, entry point, and dependency state
- `site-open <path-or-name>` — analyse, serve, and open the project
- `site-status` — show the recorded server, project, URL, PID, and log
- `site-stop` — safely stop the recorded website server

## Stack support
- Static HTML
- PHP
- Vite
- Next.js
- Create React App
- Angular
- Astro
- Nuxt
- Generic Node.js

Package-manager detection supports npm, pnpm, Yarn, and Bun.

## Safety and usability
- rejects ZIP absolute paths and parent-directory traversal before extraction
- excludes `.git`, `node_modules`, and toolkit runtime folders from searches
- prompts before installing missing JavaScript dependencies
- provides `--dry-run`, `--no-open`, `--root`, and `--port`
- validates the selected port and detects occupied ports when the platform permits
- stores logs and server state under the toolkit runtime
- records process start identity so `site-stop` does not kill an unrelated reused PID
- keeps the shared website helper internal instead of exposing it as a user command

## Verification
- all Bash files pass syntax validation
- installation and reinstallation smoke tests pass
- search with paths containing spaces passes
- static stack detection and launch-command generation pass
- unsafe ZIP traversal is rejected
- help checks pass for every new command
- `git diff --check` passes