### PR TITLE
Add project rescue and client delivery tools

### DIFF
--- a/.github/workflows/shell.yml
+++ b/.github/workflows/shell.yml
@@ -28,3 +28,5 @@ jobs:
         run: bash tests/install-smoke.sh
       - name: Test website tools
         run: bash tests/website-tools.sh
+      - name: Test project rescue tools
+        run: bash tests/project-rescue-tools.sh

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The project is currently in **v1.0-alpha**.
 - 🧑‍💻 **dev**: `newproject`
 - 🌐 **network**: `ping-check`, `dns-debug`
 - 🌍 **website projects**: `project-find`, `project-info`, `site-open`, `site-status`, `site-stop`
+- 🧰 **project rescue**: `site-doctor`, `site-build-check`, `site-env-check`, `secret-check`
+- 📦 **client delivery**: `client-package`, `handoff-report`, `repo-status-all`
 
 ## Installation
 ```bash
@@ -85,6 +87,20 @@ Angular, Astro, Nuxt and generic Node.js projects. Unknown project code is not
 executed silently: missing JavaScript dependencies require confirmation before
 the package manager is run. Use `site-open <name> --dry-run` to inspect the
 detected project and launch command without starting anything.
+
+Before delivering a project, the rescue tools can audit its setup, compare
+environment-variable names without revealing values, scan for probable secrets,
+run its production build, create a clean delivery ZIP and generate a Markdown
+handoff document:
+
+```bash
+site-doctor ./client-site
+site-env-check ./client-site
+secret-check ./client-site
+site-build-check ./client-site --dry-run
+client-package ./client-site --dry-run
+handoff-report ./client-site
+```
 
 ### Security Module
 Run `mini-man security` to view commands such as malware scans, backups and network checks.

--- a/man/dev/handoff-report.man
+++ b/man/dev/handoff-report.man
@@ -1,0 +1,7 @@
+handoff-report - generate a Markdown project handoff guide
+
+USAGE
+  handoff-report <project> [--output <markdown-file>]
+
+Includes stack, package manager, safe repository details, setup/build commands,
+environment guidance and a client handoff checklist.

--- a/man/dev/site-build-check.man
+++ b/man/dev/site-build-check.man
@@ -1,0 +1,7 @@
+site-build-check - verify a website production build
+
+USAGE
+  site-build-check <project> [--dry-run] [--yes]
+
+The command previews the build first and confirms before installing dependencies
+or executing project code. Build output is saved in toolkit logs.

--- a/man/dev/site-doctor.man
+++ b/man/dev/site-doctor.man
@@ -1,0 +1,7 @@
+site-doctor - run non-destructive website project diagnostics
+
+USAGE
+  site-doctor <project-or-name>
+
+Checks stack detection, package manager, dependencies, scripts, lockfiles,
+environment setup, Git and README presence without executing project code.

--- a/man/dev/site-env-check.man
+++ b/man/dev/site-env-check.man
@@ -1,0 +1,6 @@
+site-env-check - compare environment-variable names without showing values
+
+USAGE
+  site-env-check <project> [--example <file>] [--env <file>]
+
+Returns a failure status when required keys are missing.

--- a/man/files/client-package.man
+++ b/man/files/client-package.man
@@ -1,0 +1,7 @@
+client-package - create a clean project delivery ZIP
+
+USAGE
+  client-package <project> [--output <zip>] [--dry-run] [--yes]
+
+Excludes Git history, dependencies, caches, build output, logs, environment
+files and editor metadata. Runs secret-check before packaging.

--- a/man/git/repo-status-all.man
+++ b/man/git/repo-status-all.man
@@ -1,0 +1,7 @@
+repo-status-all - summarize Git repositories below a directory
+
+USAGE
+  repo-status-all [directory]
+
+Shows each repository's branch, clean/modified state and ahead/behind counts
+without fetching or changing any repository.

--- a/man/security/secret-check.man
+++ b/man/security/secret-check.man
@@ -1,0 +1,7 @@
+secret-check - scan a project for probable credentials
+
+USAGE
+  secret-check [project]
+
+Reports only filenames, line numbers and rule names. Secret values are never
+printed. Findings require manual review and may include false positives.

--- a/man/system/termux-doctor.man
+++ b/man/system/termux-doctor.man
@@ -1,0 +1,7 @@
+termux-doctor - diagnose the Termux and toolkit installation
+
+USAGE
+  termux-doctor
+
+Checks PREFIX, PATH, shared storage, essential commands, update source, toolkit
+launcher links and available storage. It does not modify the installation.

--- a/scripts/dev/handoff-report.sh
+++ b/scripts/dev/handoff-report.sh
@@ -1,0 +1,68 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+usage() { echo "Usage: handoff-report <project> [--output <markdown-file>]"; }
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+[[ $# -ge 1 ]] || { usage >&2; exit 2; }
+project="$(website_resolve_project "$1")"; shift
+output="$project/HANDOFF.md"
+while (($#)); do
+  case $1 in --output) output="${2:-}"; shift 2 ;; *) log_error "Unknown option: $1"; exit 2 ;; esac
+done
+stack="$(website_stack "$project")" manager="$(website_package_manager "$project")"
+remote="Not configured" branch="Not a Git repository"
+if [[ -d "$project/.git" ]]; then
+  remote="$(git -C "$project" remote get-url origin 2>/dev/null || echo 'Not configured')"
+  remote="$(sed -E 's#(https?://)[^/@]+@#\1[credentials-hidden]@#' <<< "$remote")"
+  branch="$(git -C "$project" branch --show-current 2>/dev/null || echo unknown)"
+fi
+mkdir -p "$(dirname "$output")"
+{
+  echo "# Project Handoff: $(basename "$project")"
+  echo
+  echo "Generated: $(date '+%Y-%m-%d %H:%M')"
+  echo
+  echo "## Technical overview"
+  echo
+  echo "- Stack: $stack"
+  echo "- Package manager: $manager"
+  echo "- Repository: $remote"
+  echo "- Branch: $branch"
+  echo
+  echo "## Setup"
+  echo
+  if [[ $manager != none ]]; then
+    echo '```bash'
+    echo "$manager install"
+    website_has_script "$project" dev && echo "$manager run dev"
+    echo '```'
+  else
+    echo "Open or serve the project directory according to the detected $stack stack."
+  fi
+  echo
+  echo "## Production"
+  echo
+  if website_has_script "$project" build; then
+    echo '```bash'
+    echo "$manager run build"
+    echo '```'
+  else
+    echo "No production build script was detected."
+  fi
+  echo
+  echo "## Environment"
+  echo
+  [[ -f "$project/.env.example" ]] && echo "Copy .env.example to .env and supply the required values." \
+    || echo "No .env.example file was detected."
+  echo
+  echo "## Handoff checklist"
+  echo
+  echo "- [ ] Production build passes"
+  echo "- [ ] Environment variables are configured"
+  echo "- [ ] Domain and deployment access transferred"
+  echo "- [ ] Analytics and forms verified"
+  echo "- [ ] Client credentials shared through a secure channel"
+} > "$output"
+log_success "Handoff report created: $output"

--- a/scripts/dev/site-build-check.sh
+++ b/scripts/dev/site-build-check.sh
@@ -1,0 +1,33 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+usage() { echo "Usage: site-build-check <project> [--dry-run] [--yes]"; }
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+[[ $# -ge 1 ]] || { usage >&2; exit 2; }
+project="$(website_resolve_project "$1")"; shift
+dry_run=false assume_yes=false
+while (($#)); do
+  case $1 in --dry-run) dry_run=true ;; --yes) assume_yes=true ;; *) log_error "Unknown option: $1"; exit 2 ;; esac
+  shift
+done
+manager="$(website_package_manager "$project")"
+[[ $manager != none ]] || { log_error "No JavaScript package manifest was detected."; exit 1; }
+website_has_script "$project" build || { log_error "package.json has no build script."; exit 1; }
+command=("$manager" run build)
+printf 'Project: %s\nCommand:' "$project"; printf ' %q' "${command[@]}"; echo
+[[ $dry_run == true ]] && exit 0
+if [[ ! -d "$project/node_modules" ]]; then
+  [[ $assume_yes == true ]] || ask_confirm "Dependencies are missing. Run '$manager install'?" || exit 1
+  (cd "$project" && "$manager" install)
+fi
+[[ $assume_yes == true ]] || ask_confirm "Run the project's production build code now?" || exit 0
+log="$HOME/.termux-toolkit/logs/site-build-$(date +%Y%m%d-%H%M%S).log"
+mkdir -p "$(dirname "$log")"
+if (cd "$project" && "${command[@]}") 2>&1 | tee "$log"; then
+  log_success "Production build passed. Log: $log"
+else
+  log_error "Production build failed. Log: $log"
+  exit 1
+fi

--- a/scripts/dev/site-doctor.sh
+++ b/scripts/dev/site-doctor.sh
@@ -1,0 +1,37 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+usage() { echo "Usage: site-doctor <project-or-name>"; }
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+[[ $# -eq 1 ]] || { usage >&2; exit 2; }
+project="$(website_resolve_project "$1")"
+stack="$(website_stack "$project")"
+manager="$(website_package_manager "$project")"
+warnings=0 errors=0
+
+pass() { echo "PASS  $*"; }
+warn() { echo "WARN  $*"; warnings=$((warnings + 1)); }
+fail() { echo "FAIL  $*"; errors=$((errors + 1)); }
+
+echo "Project: $project"
+echo "Stack: $stack"
+echo "Package manager: $manager"
+[[ $stack != Unknown ]] && pass "Technology stack detected" || fail "Technology stack was not recognized"
+if [[ $manager != none ]]; then
+  command -v "$manager" >/dev/null 2>&1 && pass "$manager is installed" || fail "$manager is not installed"
+  [[ -d "$project/node_modules" ]] && pass "Dependencies are installed" || warn "node_modules is missing"
+  website_has_script "$project" dev && pass "Development script exists" || warn "No dev script in package.json"
+  website_has_script "$project" build && pass "Production build script exists" || fail "No build script in package.json"
+  [[ -f "$project/package-lock.json" || -f "$project/pnpm-lock.yaml" || -f "$project/yarn.lock" || -f "$project/bun.lockb" ]] \
+    && pass "Dependency lockfile exists" || warn "No dependency lockfile found"
+fi
+[[ -f "$project/.env.example" ]] && {
+  [[ -f "$project/.env" ]] && pass ".env exists" || warn ".env.example exists but .env is missing"
+}
+[[ -d "$project/.git" ]] && pass "Git repository detected" || warn "Project is not a Git repository"
+[[ -f "$project/README.md" ]] && pass "README exists" || warn "README is missing"
+
+echo "Summary: $errors failure(s), $warnings warning(s)"
+((errors == 0))

--- a/scripts/dev/site-env-check.sh
+++ b/scripts/dev/site-env-check.sh
@@ -1,0 +1,44 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/website-common.sh"
+
+usage() { echo "Usage: site-env-check <project> [--example <file>] [--env <file>]"; }
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+[[ $# -ge 1 ]] || { usage >&2; exit 2; }
+project="$(website_resolve_project "$1")"; shift
+example="$project/.env.example" env_file="$project/.env"
+while (($#)); do
+  case $1 in
+    --example) example="${2:-}"; shift 2 ;;
+    --env) env_file="${2:-}"; shift 2 ;;
+    *) log_error "Unknown option: $1"; exit 2 ;;
+  esac
+done
+[[ -f $example ]] || { log_error "Environment example not found: $example"; exit 1; }
+
+env_keys() {
+  sed -nE 's/^[[:space:]]*(export[[:space:]]+)?([A-Za-z_][A-Za-z0-9_]*)=.*/\2/p' "$1" | sort -u
+}
+
+expected="$(mktemp)" actual="$(mktemp)"
+trap 'rm -f "$expected" "$actual"' EXIT
+env_keys "$example" > "$expected"
+[[ -f $env_file ]] && env_keys "$env_file" > "$actual" || : > "$actual"
+
+missing="$(comm -23 "$expected" "$actual")"
+extra="$(comm -13 "$expected" "$actual")"
+echo "Example: $example"
+echo "Environment: $env_file"
+echo "Expected keys: $(wc -l < "$expected" | tr -d ' ')"
+if [[ -n $missing ]]; then
+  echo "Missing keys:"
+  sed 's/^/ - /' <<< "$missing"
+else
+  echo "Missing keys: none"
+fi
+if [[ -n $extra ]]; then
+  echo "Additional keys (values hidden):"
+  sed 's/^/ - /' <<< "$extra"
+fi
+[[ -z $missing ]]

--- a/scripts/dev/website-common.sh
+++ b/scripts/dev/website-common.sh
@@ -129,3 +129,8 @@ website_package_manager() {
   [[ -f "$dir/package.json" ]] && { echo npm; return; }
   echo none
 }
+
+website_has_script() {
+  local dir="$1" script="$2"
+  [[ -f "$dir/package.json" ]] && grep -Eq "\"$script\"[[:space:]]*:" "$dir/package.json"
+}

--- a/scripts/files/client-package.sh
+++ b/scripts/files/client-package.sh
@@ -1,0 +1,41 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../dev/website-common.sh"
+
+usage() { echo "Usage: client-package <project> [--output <zip>] [--dry-run] [--yes]"; }
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+[[ $# -ge 1 ]] || { usage >&2; exit 2; }
+project="$(website_resolve_project "$1")"; shift
+name="$(basename "$project")"
+output="$PWD/${name// /-}-delivery-$(date +%Y%m%d).zip"
+dry_run=false assume_yes=false
+while (($#)); do
+  case $1 in
+    --output) output="${2:-}"; shift 2 ;;
+    --dry-run) dry_run=true; shift ;;
+    --yes) assume_yes=true; shift ;;
+    *) log_error "Unknown option: $1"; exit 2 ;;
+  esac
+done
+output="$(realpath -m "$output")"
+
+echo "Project: $project"
+echo "Output: $output"
+echo "Excluded: .git, node_modules, build caches, logs, .env files and local editor files"
+if bash "$(dirname "${BASH_SOURCE[0]}")/../security/secret-check.sh" "$project" >/dev/null 2>&1; then
+  echo "Secret scan: clear"
+else
+  log_warn "Secret scan found possible credentials. They are excluded only when stored in .env files."
+  bash "$(dirname "${BASH_SOURCE[0]}")/../security/secret-check.sh" "$project" || true
+  [[ $assume_yes == true ]] || ask_confirm "Continue packaging after reviewing secret-check output?" || exit 1
+fi
+[[ $dry_run == true ]] && exit 0
+[[ $assume_yes == true ]] || ask_confirm "Create the client delivery ZIP?" || exit 0
+require_tool zip zip || exit 1
+mkdir -p "$(dirname "$output")"
+(cd "$(dirname "$project")" && zip -qr "$output" "$name" \
+  -x "$name/.git/*" "$name/node_modules/*" "$name/.next/*" "$name/dist/*" "$name/build/*" \
+     "$name/.cache/*" "$name/.env" "$name/.env.local" "$name/.env.*.local" "$name/*.log" "$name/.DS_Store" \
+     "$name/.vscode/*" "$name/.idea/*")
+log_success "Client package created: $output"

--- a/scripts/git/repo-status-all.sh
+++ b/scripts/git/repo-status-all.sh
@@ -1,0 +1,21 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+usage() { echo "Usage: repo-status-all [directory]"; }
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+root="$(realpath "${1:-$HOME}")"
+[[ -d $root ]] || { log_error "Directory not found: $root"; exit 2; }
+
+printf '%-32s %-18s %-8s %-7s %-7s\n' "REPOSITORY" "BRANCH" "STATE" "AHEAD" "BEHIND"
+printf '%-32s %-18s %-8s %-7s %-7s\n' "----------" "------" "-----" "-----" "------"
+while IFS= read -r git_dir; do
+  repo="${git_dir%/.git}"
+  branch="$(git -C "$repo" branch --show-current 2>/dev/null || true)"
+  [[ -n $branch ]] || branch="detached"
+  [[ -n $(git -C "$repo" status --porcelain 2>/dev/null) ]] && state="modified" || state="clean"
+  counts="$(git -C "$repo" rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null || echo '0 0')"
+  behind="${counts%%[[:space:]]*}"; ahead="${counts##*[[:space:]]}"
+  printf '%-32s %-18s %-8s %-7s %-7s\n' "${repo#$root/}" "$branch" "$state" "$ahead" "$behind"
+done < <(find "$root" -type d \( -name node_modules -o -name .termux-toolkit \) -prune -o -type d -name .git -print 2>/dev/null | sort)

--- a/scripts/security/secret-check.sh
+++ b/scripts/security/secret-check.sh
@@ -1,0 +1,39 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/../system/toolkit-core.sh"
+
+usage() { echo "Usage: secret-check [project]"; }
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+project="$(realpath "${1:-.}")"
+[[ -d $project ]] || { log_error "Directory not found: $project"; exit 2; }
+
+findings=0
+report_match() {
+  local file="$1" rule="$2" pattern="$3" lines
+  lines="$(grep -nEi "$pattern" "$file" 2>/dev/null | cut -d: -f1 | sort -nu || true)"
+  while IFS= read -r line; do
+    [[ -n $line ]] || continue
+    printf '%s:%s [%s]\n' "${file#$project/}" "$line" "$rule"
+    findings=$((findings + 1))
+  done <<< "$lines"
+}
+
+while IFS= read -r -d '' file; do
+  grep -Iq . "$file" 2>/dev/null || continue
+  report_match "$file" "private-key" 'BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY'
+  report_match "$file" "github-token" 'gh[pousr]_[A-Za-z0-9]{20,}'
+  report_match "$file" "openai-key" 'sk-[A-Za-z0-9_-]{20,}'
+  report_match "$file" "aws-access-key" 'AKIA[0-9A-Z]{16}'
+  report_match "$file" "probable-secret" '(api[_-]?(key|token)|secret|token|password)[[:space:]]*[=:][[:space:]]*[-A-Za-z0-9_./+=]{12,}'
+done < <(find "$project" \
+  \( -path '*/.git' -o -path '*/node_modules' -o -path '*/.next' -o -path '*/dist' \
+     -o -path '*/build' \) -prune -o \
+  \( -name '*.lock' -o -name 'package-lock.json' \) -prune -o \
+  -type f -size -2M -print0)
+
+if ((findings)); then
+  log_warn "$findings possible secret location(s) found. Values were not printed."
+  exit 1
+fi
+log_success "No probable secrets found by the local rules."

--- a/scripts/system/termux-doctor.sh
+++ b/scripts/system/termux-doctor.sh
@@ -1,0 +1,36 @@
+#!/data/data/com.termux/files/usr/bin/bash
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/toolkit-core.sh"
+
+usage() { echo "Usage: termux-doctor"; }
+[[ ${1:-} == -h || ${1:-} == --help ]] && { usage; exit 0; }
+
+warnings=0 failures=0
+pass() { echo "PASS  $*"; }
+warn() { echo "WARN  $*"; warnings=$((warnings + 1)); }
+fail() { echo "FAIL  $*"; failures=$((failures + 1)); }
+
+echo "Termux Toolkit health check"
+[[ ${PREFIX:-} == */com.termux/* ]] && pass "Termux PREFIX detected" || fail "This does not appear to be Termux"
+[[ -d "$HOME/storage/shared" ]] && pass "Shared storage is available" || warn "Run termux-setup-storage"
+[[ ":$PATH:" == *":${PREFIX:-/missing}/bin:"* ]] && pass "Termux bin directory is on PATH" || fail "Termux bin is missing from PATH"
+for command in bash git python ttk; do
+  command -v "$command" >/dev/null 2>&1 && pass "$command is available" || warn "$command is not installed or not on PATH"
+done
+[[ -f "$HOME/.termux-toolkit/source-dir" ]] && pass "Toolkit update source is recorded" || warn "Toolkit update source is missing"
+broken=0
+if [[ -d "${PREFIX:-/missing}/bin" ]]; then
+  while IFS= read -r link; do
+    [[ -e $link ]] || { echo "WARN  Broken toolkit launcher: $link"; broken=$((broken + 1)); }
+  done < <(find "${PREFIX:-/missing}/bin" -maxdepth 1 -type l -lname "$HOME/.termux-toolkit/bin/*" 2>/dev/null)
+fi
+warnings=$((warnings + broken))
+available="$(df -Pk "$HOME" 2>/dev/null | awk 'NR==2 {print $4}')"
+if [[ $available =~ ^[0-9]+$ && $available -lt 524288 ]]; then
+  warn "Less than 512 MB of free storage remains"
+else
+  pass "Storage has at least 512 MB free"
+fi
+echo "Summary: $failures failure(s), $warnings warning(s)"
+((failures == 0))

--- a/tests/project-rescue-tools.sh
+++ b/tests/project-rescue-tools.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="$TEST_ROOT/home" PREFIX="$TEST_ROOT/prefix"
+export PATH="$PREFIX/bin:/usr/bin:/bin:$PATH"
+project="$TEST_ROOT/project"
+mkdir -p "$HOME" "$PREFIX/bin" "$project/.git"
+cat > "$PREFIX/bin/pkg" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$PREFIX/bin/pkg"
+
+cat > "$project/package.json" <<'EOF'
+{
+  "scripts": {"dev": "vite", "build": "vite build"},
+  "dependencies": {"vite": "latest"}
+}
+EOF
+touch "$project/package-lock.json"
+cat > "$project/.env.example" <<'EOF'
+API_URL=
+PUBLIC_NAME=
+EOF
+cat > "$project/.env" <<'EOF'
+API_URL=https://example.test
+EOF
+printf '# Test project\n' > "$project/README.md"
+
+bash "$REPO_ROOT/install-toolkit.sh" >/dev/null
+
+doctor=$(bash "$PREFIX/bin/site-doctor" "$project" || true)
+grep -q 'Stack: Node.js' <<< "$doctor"
+grep -q 'Production build script exists' <<< "$doctor"
+
+if bash "$PREFIX/bin/site-env-check" "$project" >/dev/null; then
+  echo "Missing environment key was not detected" >&2
+  exit 1
+fi
+printf 'PUBLIC_NAME=test\n' >> "$project/.env"
+bash "$PREFIX/bin/site-env-check" "$project" >/dev/null
+
+printf 'API_TOKEN=abcdefghijklmnopqrstuvwxyz123456\n' > "$project/config.txt"
+if bash "$PREFIX/bin/secret-check" "$project" >/dev/null 2>&1; then
+  echo "Probable secret was not detected" >&2
+  exit 1
+fi
+rm -f "$project/config.txt"
+bash "$PREFIX/bin/secret-check" "$project" >/dev/null
+
+build_preview=$(bash "$PREFIX/bin/site-build-check" "$project" --dry-run)
+grep -q 'npm run build' <<< "$build_preview"
+
+package_preview=$(bash "$PREFIX/bin/client-package" "$project" --dry-run)
+grep -q 'Excluded:' <<< "$package_preview"
+
+report="$TEST_ROOT/HANDOFF.md"
+bash "$PREFIX/bin/handoff-report" "$project" --output "$report" >/dev/null
+grep -q 'Project Handoff' "$report"
+grep -q 'npm run build' "$report"
+
+echo "Project rescue tool tests passed"


### PR DESCRIPTION
## Summary

Adds a practical project-rescue and client-delivery workflow to Termux Toolkit.

### New commands

- `site-doctor` — inspect stack, dependencies, scripts, environment setup, Git and documentation
- `site-env-check` — compare environment-variable names without printing values
- `secret-check` — report probable credential locations without exposing their contents
- `site-build-check` — preview and safely run a production build
- `client-package` — create a clean delivery ZIP with local and generated files excluded
- `handoff-report` — generate a Markdown setup and delivery guide
- `repo-status-all` — summarize local repositories without fetching or modifying them
- `termux-doctor` — diagnose Termux, storage, PATH and toolkit installation health

Each command includes a mini-man manual. The README now documents the end-to-end rescue workflow.

## Safety

- Project code is not executed by diagnostics.
- Dependency installation and builds require confirmation unless `--yes` is explicitly supplied.
- Secret findings show only file names, line numbers and rule names.
- Delivery archives exclude Git data, dependencies, build caches, logs and local environment files, while retaining `.env.example`.
- ZIP creation supports `--dry-run`.

## Tests

- Bash syntax checks for all scripts
- `bash tests/install-smoke.sh`
- `bash tests/website-tools.sh`
- `bash tests/project-rescue-tools.sh`
- `git diff --check`

CI now runs the new rescue-tool test suite.